### PR TITLE
Update the plural of WPAs

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -38,7 +38,7 @@ rules:
 - apiGroups:
   - apps
   resourceNames:
-  - watermarkpodautoscaler
+  - watermarkpodautoscalers
   resources:
   - deployments/finalizers
   verbs:

--- a/deploy/crds/datadoghq_v1alpha1_watermarkpodautoscaler_crd.yaml
+++ b/deploy/crds/datadoghq_v1alpha1_watermarkpodautoscaler_crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: watermarkpodautoscaler.datadoghq.com
+  name: watermarkpodautoscalers.datadoghq.com
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.currentMetrics[*].external.currentValue..
@@ -26,7 +26,7 @@ spec:
   names:
     kind: WatermarkPodAutoscaler
     listKind: WatermarkPodAutoscalerList
-    plural: watermarkpodautoscaler
+    plural: watermarkpodautoscalers
     shortNames:
     - wpa
     singular: watermarkpodautoscaler

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: watermarkpodautoscaler
+  name: watermarkpodautoscalers
 spec:
   replicas: 1
   selector:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -31,7 +31,7 @@ rules:
 - apiGroups:
   - apps
   resourceNames:
-  - watermarkpodautoscaler
+  - watermarkpodautoscalers
   resources:
   - deployments/finalizers
   verbs:

--- a/pkg/apis/datadoghq/v1alpha1/watermarkpodautoscaler_types.go
+++ b/pkg/apis/datadoghq/v1alpha1/watermarkpodautoscaler_types.go
@@ -126,7 +126,7 @@ type WatermarkPodAutoscalerStatus struct {
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="min replicas",type="integer",JSONPath=".spec.minReplicas"
 // +kubebuilder:printcolumn:name="max replicas",type="integer",JSONPath=".spec.maxReplicas"
-// +kubebuilder:resource:path=watermarkpodautoscaler,shortName=wpa
+// +kubebuilder:resource:path=watermarkpodautoscalers,shortName=wpa
 type WatermarkPodAutoscaler struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
DCA was throwing:
```
E0912 21:17:19.375030       1 reflector.go:125] github.com/DataDog/watermarkpodautoscaler/pkg/client/informers/externalversions/factory.go:108: Failed to list *v1alpha1.WatermarkPodAutoscaler: watermarkpodautoscalers.datadoghq.com is forbidden: User "system:serviceaccount:default:dca" cannot list resource "watermarkpodautoscalers" in API group "datadoghq.com" at the cluster scope
```

Realised that I did not properly configured the path.
updated the kubebuilder annotation in the `types`.

FWIW I `operator-sdk generate k8s|open-api`

As editing the CRD directly yields:
```
kubectl apply -f deploy/crds/datadoghq_v1alpha1_watermarkpodautoscaler_crd.yaml
The CustomResourceDefinition "watermarkpodautoscaler.datadoghq.com" is invalid: spec.names.plural: Invalid value: "watermarkpodautoscalers": field is immutable
```

And only updating the `plural` part yields:
```The CustomResourceDefinition "watermarkpodautoscaler.datadoghq.com" is invalid: metadata.name: Invalid value: "watermarkpodautoscaler.datadoghq.com": must be spec.names.plural+"."+spec.group```

Also updated the RBACs.

```
➜  watermarkpodautoscaler git:(update-type) ✗ k get watermarkpodautoscalers.datadoghq.com
No resources found.
➜  watermarkpodautoscaler git:(update-type) ✗ k get watermarkpodautoscalers
No resources found.
➜  watermarkpodautoscaler git:(update-type) ✗ k get watermarkpodautoscaler
No resources found.
➜  watermarkpodautoscaler git:(update-type) ✗ k get wpa
No resources found.
```
I had to delete the former crd without the plural and I believe there is a caching situation too as for a few minutes I was getting:
```

Error from server (NotFound): Unable to list "datadoghq.com/v1alpha1, Resource=watermarkpodautoscaler": the server could not find the requested resource (get watermarkpodautoscaler.datadoghq.com)
```