### PR TITLE
Consistent labels (and extra replicas metrics)

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
   - 'get'
 - apiGroups:
   - apps
+  - extensions
   resourceNames:
   - watermarkpodautoscalers
   resources:

--- a/deploy/crds/datadoghq_v1alpha1_watermarkpodautoscaler_cr.yaml
+++ b/deploy/crds/datadoghq_v1alpha1_watermarkpodautoscaler_cr.yaml
@@ -9,6 +9,7 @@ spec:
   tolerance: 0.01
   scaleTargetRef:
     kind: Deployment
+    apiVersion: apps/v1
     name: alpine
   metrics:
   - type: External

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -32,6 +32,7 @@ rules:
   - get
 - apiGroups:
   - apps
+  - extensions
   resources:
   - replicasets/scale
   - deployments/scale


### PR DESCRIPTION
This is really to open a discussion, as I understand changing labels might
break downstream users dashboards/monitors (or maybe it's still time to do so?).

The current metrics labeling might not be the easiest to work with:
* To build a complete dashboard or monitor, one have to duplicate the same dashboard variables; and wpa dashboard viewers must configure them before they can see their relevant graphs:
  * `deployment` is the label exposed by KSM (exposes real current replicas value; also available/unavail pods)
  * `kube_deployment` is used on kubelet metrics (ie. pods `kubernetes.cpu.usage.total`)
  * `deploy` is the label WPA controller exposes, for _some_ metrics only
  * `wpa_name` is the only label WPA controller consistently add to every metrics. But using this label would be unnecessary if all metrics were tagged with the target deployment name.
* WPA objects (and the target deployments) are namespaced: we could have several deployments by the same name in different namespaces. Misleadingly, we get the controller's namespace label from the agent scrapping the controller's metrics.

Choosing between the Agent's/kubelet labels names (ie. `kube_deployment`) vs. KSM's
(ie. `deployment`) is a bit arbitrary.

It seemed more natural to standardize on our own labels (`kube_` prefixed) than KSM,
since users are much more likely to use those (eg. from kubelet) as scaling value,
while KSM's deployment metrics are only relevant here to display the replicas numbers
by states, which the WPA controller should export anyway. This PR does so, to present
a comprehensive and easier to use deployment's replicas view, and to avoid requiering
the heavy and unreliable KSM.

nb: a deployment objectkind was already implied at many places, but is there
a reason not to abstract workload and also support statefulsets? (later on)