### PR TITLE
Moving WPA to beta for the KEP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Watermark Pod Autoscaler Controller
 
-**Disclaimer**: This project is still a work in progress, the API might change.
+**Disclaimer**: This project is in beta - The API might change.
 
 ## Overview
 


### PR DESCRIPTION
In preparation of the Kubernetes Enhancement Proposal we need to officially move the controller to Beta.