### PR TITLE
Fix RBAC & Scale Target missing

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -5,13 +5,21 @@ metadata:
 rules:
 - apiGroups:
   - apps
+  - extensions
   resources:
   - replicasets/scale
   - deployments/scale
   - statefulsets/scale
   verbs:
-  - 'update'
-  - 'get'
+  - update
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - apps
   - extensions


### PR DESCRIPTION
- Adding rights on event to CR 
The out of the box CR is missing the verb patch for events which yields:
```
E0127 20:43:23.071157       1 event.go:237] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"watermar [...] is forbidden: User "system:serviceaccount:default:watermarkpodautoscaler" cannot patch resource "events" in API group "" in the namespace "default"' (will not retry!)
```

- Add logic to not crash if target does not exist, as raised here https://github.com/DataDog/watermarkpodautoscaler/issues/43

