### PR TITLE
Fixing the pod informer selector 

### DIFF
--- a/pkg/controller/watermarkpodautoscaler/replica_calculator.go
+++ b/pkg/controller/watermarkpodautoscaler/replica_calculator.go
@@ -104,7 +104,6 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, target
 	// if the average algorithm is used, the metrics retrieved has to be divided by the number of available replicas.
 	adjustedUsage := float64(sum) / averaged
 	replicaCount, utilizationQuantity := getReplicaCount(logger, target.Status.Replicas, currentReadyReplicas, wpa, metricName, adjustedUsage, metric.External.LowWatermark, metric.External.HighWatermark)
-	log.Info("getRep", "currentReplicas", target.Status.Replicas, "currentReadyReplicas", currentReadyReplicas, "replicaCount", replicaCount)
 	return ReplicaCalculation{replicaCount, utilizationQuantity, timestamp}, nil
 }
 
@@ -245,7 +244,7 @@ func (c *ReplicaCalculator) getReadyPodsCount(target *autoscalingv1.Scale, selec
 }
 func checkOwnerRef(ownerRef []metav1.OwnerReference, targetName string) bool {
 	for _, o := range ownerRef {
-		if o.Kind != "ReplicaSet" {
+		if o.Kind != "ReplicaSet" && o.Kind != "StatefulSet" {
 			continue
 		}
 		if strings.HasPrefix(o.Name, targetName) {

--- a/pkg/controller/watermarkpodautoscaler/replica_calculator.go
+++ b/pkg/controller/watermarkpodautoscaler/replica_calculator.go
@@ -137,7 +137,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 		value.Delete(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: string(resourceName)})
 		return ReplicaCalculation{0, 0, time.Time{}}, fmt.Errorf("unable to get resource metric %s/%s/%+v: %s", wpa.Namespace, resourceName, selector, err)
 	}
-	logger.V(4).Info("Metrics from the Resource Client", "metrics", metrics)
+	logger.Info("Metrics from the Resource Client", "metrics", metrics)
 
 	lbl, err := labels.Parse(target.Status.Selector)
 	if err != nil {
@@ -244,6 +244,7 @@ func (c *ReplicaCalculator) getReadyPodsCount(target *autoscalingv1.Scale, selec
 	return int32(toleratedAsReadyPodCount), nil
 }
 func checkOwnerRef(ownerRef []metav1.OwnerReference, target *autoscalingv1.Scale) bool {
+	log.Info("Owner ref", "OwnerRef", ownerRef, "target", target.Name)
 	for _, o := range ownerRef {
 		if o.Kind != "ReplicaSet" {
 			continue
@@ -260,6 +261,10 @@ func groupPods(logger logr.Logger, podList []*corev1.Pod, metrics metricsclient.
 	ignoredPods = sets.NewString()
 	missing := sets.NewString()
 	for _, pod := range podList {
+		// TODO
+		//if ok := checkOwnerRef(pod.OwnerReferences, target); !ok {
+		//	continue
+		//}
 		// Failed pods shouldn't produce metrics, but add to ignoredPods to be safe
 		if pod.Status.Phase == corev1.PodFailed {
 			ignoredPods.Insert(pod.Name)

--- a/pkg/controller/watermarkpodautoscaler/replica_calculator_test.go
+++ b/pkg/controller/watermarkpodautoscaler/replica_calculator_test.go
@@ -64,6 +64,7 @@ type replicaCalcTestCase struct {
 
 const (
 	testReplicaSetName  = "foo-bar-123-345"
+	replicaSetKind      = "ReplicaSet"
 	testDeploymentName  = "foo-bar-123"
 	testNamespace       = "test-namespace"
 	podNamePrefix       = "test-pod"
@@ -202,7 +203,7 @@ func (tc *replicaCalcTestCase) prepareTestClientSet() *fake.Clientset {
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind: "ReplicaSet",
+							Kind: replicaSetKind,
 							Name: testReplicaSetName,
 						},
 					},
@@ -1508,6 +1509,7 @@ func TestGroupPods(t *testing.T) {
 
 	tests := []struct {
 		name                string
+		targetName          string
 		pods                []*corev1.Pod
 		metrics             metrics.PodMetricsInfo
 		resource            corev1.ResourceName
@@ -1516,6 +1518,7 @@ func TestGroupPods(t *testing.T) {
 	}{
 		{
 			"void",
+			"",
 			[]*corev1.Pod{},
 			metrics.PodMetricsInfo{},
 			corev1.ResourceCPU,
@@ -1524,10 +1527,15 @@ func TestGroupPods(t *testing.T) {
 		},
 		{
 			"count in a ready pod - memory",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bentham",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1543,10 +1551,15 @@ func TestGroupPods(t *testing.T) {
 		},
 		{
 			"ignore a pod without ready condition - CPU",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "lucretius",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1565,10 +1578,15 @@ func TestGroupPods(t *testing.T) {
 		},
 		{
 			"count in a ready pod with fresh metrics during initialization period - CPU",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bentham",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1594,10 +1612,15 @@ func TestGroupPods(t *testing.T) {
 		},
 		{
 			"ignore an unready pod during initialization period - CPU",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "lucretius",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1623,10 +1646,15 @@ func TestGroupPods(t *testing.T) {
 		},
 		{
 			"count in a ready pod without fresh metrics after initialization period - CPU",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "bentham",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1653,10 +1681,15 @@ func TestGroupPods(t *testing.T) {
 
 		{
 			"count in an unready pod that was ready after initialization period - CPU",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "lucretius",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1682,10 +1715,15 @@ func TestGroupPods(t *testing.T) {
 		},
 		{
 			"ignore pod that has never been ready after initialization period - CPU",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "lucretius",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1711,10 +1749,15 @@ func TestGroupPods(t *testing.T) {
 		},
 		{
 			"a missing pod",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "epicurus",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1731,10 +1774,15 @@ func TestGroupPods(t *testing.T) {
 		},
 		{
 			"several pods",
+			testDeploymentName,
 			[]*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "lucretius",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1746,6 +1794,10 @@ func TestGroupPods(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "niccolo",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1764,6 +1816,10 @@ func TestGroupPods(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "epicurus",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodSucceeded,
@@ -1782,11 +1838,88 @@ func TestGroupPods(t *testing.T) {
 			sets.NewString("lucretius"),
 		},
 		{
+			"too many pods in scope with labels",
+			testDeploymentName,
+			[]*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "lucretius",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: "not-the-right-replicaset",
+							Kind: replicaSetKind,
+						}},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+						StartTime: &metav1.Time{
+							Time: time.Now(),
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "niccolo",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: "not-the-right-replicaset",
+							Kind: replicaSetKind,
+						}},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+						StartTime: &metav1.Time{
+							Time: time.Now().Add(-3 * time.Minute),
+						},
+						Conditions: []corev1.PodCondition{
+							{
+								Type:               corev1.PodReady,
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(-3 * time.Minute)},
+								Status:             corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "epicurus",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
+					},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodSucceeded,
+						StartTime: &metav1.Time{
+							Time: time.Now(),
+						},
+						Conditions: []corev1.PodCondition{
+							{
+								Type:               corev1.PodReady,
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(-3 * time.Minute)},
+								Status:             corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			metrics.PodMetricsInfo{
+				"epicurus":  metrics.PodMetric{Value: 1},
+				"lucretius": metrics.PodMetric{Value: 1},
+				"niccolo":   metrics.PodMetric{Value: 1},
+			},
+			corev1.ResourceCPU,
+			1,
+			sets.NewString(),
+		},
+		{
 			name: "pending pods are ignored",
 			pods: []*corev1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "unscheduled",
+						OwnerReferences: []metav1.OwnerReference{{
+							Name: testReplicaSetName,
+							Kind: replicaSetKind,
+						}},
 					},
 					Status: corev1.PodStatus{
 						Phase: corev1.PodPending,
@@ -1801,10 +1934,10 @@ func TestGroupPods(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			readyPods, ignoredPods := groupPods(logf.Log, tc.pods, tc.metrics, tc.resource, time.Duration(readinessDelay)*time.Second)
+			readyPods, ignoredPods := groupPods(logf.Log, tc.pods, tc.targetName, tc.metrics, tc.resource, time.Duration(readinessDelay)*time.Second)
 			readyPodCount := len(readyPods)
-			assert.Equal(t, readyPodCount, tc.expectReadyPodCount, "%s got readyPodCount %d, expected %d", tc.name, readyPodCount, tc.expectReadyPodCount)
-			assert.EqualValues(t, ignoredPods, tc.expectIgnoredPods, "%s got unreadyPods %v, expected %v", tc.name, ignoredPods, tc.expectIgnoredPods)
+			assert.Equal(t, tc.expectReadyPodCount, readyPodCount, "%s got readyPodCount %d, expected %d", tc.name, readyPodCount, tc.expectReadyPodCount)
+			assert.EqualValues(t, tc.expectIgnoredPods, ignoredPods, "%s got unreadyPods %v, expected %v", tc.name, ignoredPods, tc.expectIgnoredPods)
 		})
 	}
 }

--- a/pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go
+++ b/pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go
@@ -343,7 +343,7 @@ func (r *ReconcileWatermarkPodAutoscaler) reconcileWPA(logger logr.Logger, wpa *
 		}
 
 		desiredReplicas = normalizeDesiredReplicas(logger, wpa, currentReplicas, desiredReplicas)
-		logger.Info("Normalized replicas", "desiredReplicas", desiredReplicas)
+		logger.Info("Normalized Desired replicas", "desiredReplicas", desiredReplicas)
 
 		rescale = shouldScale(logger, wpa, currentReplicas, desiredReplicas, now)
 	}


### PR DESCRIPTION
With the current logic, the selector used to retrieve the number of pods of the target to only use the healthy ones in the calculation of the recommendation, relies on the selector exposed by the `Scale` interface.
This selector is the one in the matchSelector in the target deploy (or sts). The issue is that this selector can be shared by multiple targets.
Therefore, you can end up in a scenario where the Target has 5 replicas and as we try to see how many out of these 5 are healthy using the pod informer, if multiple deployments have the same selector, we might see 18 pods.
The solution is to check the owner ref as well to make sure we only look at the pods that relate to the target we are autoscaling.


