### PR TITLE
add labels_info metric to support additional labels as tags

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,6 +13,8 @@ spec:
         ad.datadoghq.com/watermarkpodautoscaler.check_names: '["prometheus"]'
         ad.datadoghq.com/watermarkpodautoscaler.init_configs: '[{}]'
         ad.datadoghq.com/watermarkpodautoscaler.instances: '[{"prometheus_url": "http://%%host%%:8383/metrics","namespace":"watermarkpodautoscaler","metrics": ["wpa","wpa_controller*"]}]'
+        # sample configuration for label joins (see DD_LABELS_AS_TAGS)
+        # ad.datadoghq.com/watermarkpodautoscaler.instances: '[{"prometheus_url": "http://%%host%%:8383/metrics","namespace":"watermarkpodautoscaler","metrics": ["wpa","wpa_controller*"],"label_joins": {"wpa_controller_labels_info": {"label_to_match":"wpa_name","labels_to_get": ["label1","label2"]}}}]'
       labels:
         name: watermarkpodautoscaler
     spec:
@@ -35,3 +37,6 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "watermarkpodautoscaler"
+            # Additional labels to include as tags (requires label joins configuration for prometheus check)
+            # - name: DD_LABELS_AS_TAGS
+            #   value: "label1 label2"

--- a/pkg/controller/watermarkpodautoscaler/metrics.go
+++ b/pkg/controller/watermarkpodautoscaler/metrics.go
@@ -6,6 +6,9 @@
 package watermarkpodautoscaler
 
 import (
+	"os"
+	"strings"
+
 	datadoghqv1alpha1 "github.com/DataDog/watermarkpodautoscaler/pkg/apis/datadoghq/v1alpha1"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,6 +28,9 @@ const (
 	downscaleCappingPromLabel  = "downscale_capping"
 	upscaleCappingPromLabel    = "upscale_capping"
 )
+
+// Labels to add to an info metric and join on (with wpaNamePromLabel) in the Datadog prometheus check
+var extraPromLabels = strings.Split(os.Getenv("DD_LABELS_AS_TAGS"), " ")
 
 var (
 	value = prometheus.NewGaugeVec(
@@ -166,6 +172,14 @@ var (
 			resourceNamePromLabel,
 			resourceKindPromLabel,
 		})
+	labelsInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "labels_info",
+			Help:      "Info metric for additional labels to associate to metrics as tags",
+		},
+		append(extraPromLabels, wpaNamePromLabel),
+	)
 )
 
 func init() {
@@ -180,6 +194,7 @@ func init() {
 	sigmetrics.Registry.MustRegister(transitionCountdown)
 	sigmetrics.Registry.MustRegister(replicaMin)
 	sigmetrics.Registry.MustRegister(replicaMax)
+	sigmetrics.Registry.MustRegister(labelsInfo)
 }
 
 func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onlyMetricsSpecific bool) {
@@ -206,6 +221,13 @@ func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onl
 		transitionCountdown.Delete(promLabelsForWpa)
 		promLabelsForWpa[transitionPromLabel] = "upscale"
 		transitionCountdown.Delete(promLabelsForWpa)
+
+		promLabelsInfo := prometheus.Labels{wpaNamePromLabel: wpa.Name}
+		for _, eLabel := range extraPromLabels {
+			eLabelValue := wpa.Labels[eLabel]
+			promLabelsInfo[eLabel] = eLabelValue
+		}
+		labelsInfo.Delete(promLabelsInfo)
 	}
 
 	for _, metricSpec := range wpa.Spec.Metrics {

--- a/pkg/controller/watermarkpodautoscaler/metrics.go
+++ b/pkg/controller/watermarkpodautoscaler/metrics.go
@@ -30,7 +30,7 @@ const (
 )
 
 // Labels to add to an info metric and join on (with wpaNamePromLabel) in the Datadog prometheus check
-var extraPromLabels = strings.Split(os.Getenv("DD_LABELS_AS_TAGS"), " ")
+var extraPromLabels = strings.Fields(os.Getenv("DD_LABELS_AS_TAGS"))
 
 var (
 	value = prometheus.NewGaugeVec(

--- a/pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go
+++ b/pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go
@@ -379,6 +379,15 @@ func (r *ReconcileWatermarkPodAutoscaler) reconcileWPA(logger logr.Logger, wpa *
 	}
 
 	replicaEffective.With(prometheus.Labels{wpaNamePromLabel: wpa.Name, resourceNamespacePromLabel: wpa.Namespace, resourceNamePromLabel: wpa.Spec.ScaleTargetRef.Name, resourceKindPromLabel: wpa.Spec.ScaleTargetRef.Kind}).Set(float64(desiredReplicas))
+
+	// add additional labels to info metric
+	promLabels := prometheus.Labels{wpaNamePromLabel: wpa.Name}
+	for _, eLabel := range extraPromLabels {
+		eLabelValue := wpa.Labels[eLabel]
+		promLabels[eLabel] = eLabelValue
+	}
+	labelsInfo.With(promLabels).Set(1)
+
 	setStatus(wpa, currentReplicas, desiredReplicas, metricStatuses, rescale)
 	return r.updateStatusIfNeeded(wpaStatusOriginal, wpa)
 }


### PR DESCRIPTION
- Add an env var `DD_LABELS_AS_TAGS` that will add space-separated label keys as metric tags using label joins (with the wpa name label).

- Provides sample configuration in operator.yaml accordingly

To test:
- add desired labels in WPA CR
- update `DD_LABELS_AS_TAGS` and prometheus check configuration in operator.yaml
- confirm labels are present in prometheus metrics and tags are present in Datadog prometheus check output
