### PR TITLE
Fixing release step in gitlab pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,7 @@ push_release_tag:
   only:
     - tags
   stage: release
+  before_script: []
   tags: [ "runner:docker", "size:large" ]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:0.6.1
   script:


### PR DESCRIPTION
```
 $ mkdir -p .cache
 $ make install-tools
 go build -o bin/yq ./vendor/github.com/mikefarah/yq/v3
 make: go: Command not found
 Makefile:101: recipe for target 'bin/yq' failed
 make: *** [bin/yq] Error 127
Running after_script
00:01
Uploading artifacts for failed job
00:01
 ERROR: Job failed: exit code 1
```

before script should not be run in the release step.