### PR TITLE
Fix metrics cleanup

### DIFF
--- a/pkg/controller/watermarkpodautoscaler/replica_calculator.go
+++ b/pkg/controller/watermarkpodautoscaler/replica_calculator.go
@@ -85,11 +85,11 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, target
 			resourceNamespacePromLabel: wpa.Namespace,
 			resourceNamePromLabel:      wpa.Spec.ScaleTargetRef.Name,
 			resourceKindPromLabel:      wpa.Spec.ScaleTargetRef.Kind,
-			reasonPromLabel:            upscaleCappingPromLabel}
+			reasonPromLabel:            upscaleCappingPromLabelVal}
 		restrictedScaling.Delete(labelsWithReason)
-		labelsWithReason[reasonPromLabel] = downscaleCappingPromLabel
+		labelsWithReason[reasonPromLabel] = downscaleCappingPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
-		labelsWithReason[reasonPromLabel] = "within_bounds"
+		labelsWithReason[reasonPromLabel] = withinBoundsPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
 		value.Delete(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: metricName})
 		return ReplicaCalculation{0, 0, time.Time{}}, fmt.Errorf("unable to get external metric %s/%s/%+v: %s", wpa.Namespace, metricName, selector, err)
@@ -127,11 +127,11 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 			resourceNamespacePromLabel: wpa.Namespace,
 			resourceNamePromLabel:      wpa.Spec.ScaleTargetRef.Name,
 			resourceKindPromLabel:      wpa.Spec.ScaleTargetRef.Kind,
-			reasonPromLabel:            upscaleCappingPromLabel}
+			reasonPromLabel:            upscaleCappingPromLabelVal}
 		restrictedScaling.Delete(labelsWithReason)
-		labelsWithReason[reasonPromLabel] = downscaleCappingPromLabel
+		labelsWithReason[reasonPromLabel] = downscaleCappingPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
-		labelsWithReason[reasonPromLabel] = "within_bounds"
+		labelsWithReason[reasonPromLabel] = withinBoundsPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
 		value.Delete(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: string(resourceName)})
 		return ReplicaCalculation{0, 0, time.Time{}}, fmt.Errorf("unable to get resource metric %s/%s/%+v: %s", wpa.Namespace, resourceName, selector, err)
@@ -180,7 +180,7 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 	adjustedHM := float64(highMark.MilliValue()) + wpa.Spec.Tolerance*float64(highMark.MilliValue())
 	adjustedLM := float64(lowMark.MilliValue()) - wpa.Spec.Tolerance*float64(lowMark.MilliValue())
 
-	labelsWithReason := prometheus.Labels{wpaNamePromLabel: wpa.Name, resourceNamespacePromLabel: wpa.Namespace, resourceNamePromLabel: wpa.Spec.ScaleTargetRef.Name, resourceKindPromLabel: wpa.Spec.ScaleTargetRef.Kind, reasonPromLabel: "within_bounds"}
+	labelsWithReason := prometheus.Labels{wpaNamePromLabel: wpa.Name, resourceNamespacePromLabel: wpa.Namespace, resourceNamePromLabel: wpa.Spec.ScaleTargetRef.Name, resourceKindPromLabel: wpa.Spec.ScaleTargetRef.Kind, reasonPromLabel: withinBoundsPromLabelVal}
 	labelsWithMetricName := prometheus.Labels{wpaNamePromLabel: wpa.Name, resourceNamespacePromLabel: wpa.Namespace, resourceNamePromLabel: wpa.Spec.ScaleTargetRef.Name, resourceKindPromLabel: wpa.Spec.ScaleTargetRef.Kind, metricNamePromLabel: name}
 
 	switch {

--- a/pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go
+++ b/pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go
@@ -734,7 +734,7 @@ func convertDesiredReplicasWithRules(logger logr.Logger, wpa *datadoghqv1alpha1.
 
 	if desiredReplicas > scaleUpLimit {
 		maximumAllowedReplicas = int32(math.Min(float64(scaleUpLimit), float64(wpaMaxReplicas)))
-		promLabelsForWpa[reasonPromLabel] = upscaleCappingPromLabel
+		promLabelsForWpa[reasonPromLabel] = upscaleCappingPromLabelVal
 
 		restrictedScaling.With(promLabelsForWpa).Set(1)
 		logger.Info("Upscaling rate higher than limit of 'ScaleUpLimitFactor' up to 'maximumAllowedReplicas' replicas. Capping the maximum upscale to %d replicas", "scaleUpLimitFactor", fmt.Sprintf("%.1f%%", wpa.Spec.ScaleUpLimitFactor), "wpaMaxReplicas", wpaMaxReplicas, "maximumAllowedReplicas", maximumAllowedReplicas)


### PR DESCRIPTION
### What does this PR do?

Pass the right metric contexts to make sure we clean up the metrics correclty

### Motivation

The following metrics were not deleted when deleting the corresponding Custom Resource

- wpa_controller_high_watermark
- wpa_controller_low_watermark
- wpa_controller_restricted_scaling
- wpa_controller_value
