### PR TITLE
[wpa helm chart] Add missing rule for Pods in ClusterRole in helm chart

### DIFF
--- a/chart/watermarkpodautoscaler/templates/clusterrole.yaml
+++ b/chart/watermarkpodautoscaler/templates/clusterrole.yaml
@@ -24,6 +24,13 @@ rules:
   - create
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apps
   - extensions
   resourceNames:


### PR DESCRIPTION
### What does this PR do?

Sync rules from `deploy/clusterrole.yaml` to `chart/watermarkpodautoscaler/templates/clusterrole.yaml`, note that we don't request `get` verb which is probably ok for what we need.

### Motivation

Working RBAC in helm chart.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Ensure there are no logs similar to:
```
E0902 18:04:45.304836       1 reflector.go:123] pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go:73: Failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:default:wpacontroller-watermarkpodautoscaler" cannot list resource "pods" in API group "" at the cluster scope
```