### PR TITLE
add labelsAsTags to chart template

### DIFF
--- a/chart/watermarkpodautoscaler/Chart.yaml
+++ b/chart/watermarkpodautoscaler/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.2.0
 description: Watermark Pod Autoscaler
 name: watermarkpodautoscaler
-version: v0.2.0
+version: v0.2.1

--- a/chart/watermarkpodautoscaler/templates/deployment.yaml
+++ b/chart/watermarkpodautoscaler/templates/deployment.yaml
@@ -21,6 +21,15 @@ spec:
             "prometheus_url": "http://%%host%%:8383/metrics",
             "namespace":"watermarkpodautoscaler",
             "metrics": ["wpa","wpa_controller*"]
+            {{- if .Values.labelsAsTags -}}
+            ,
+            "label_joins": {
+              "wpa_controller_labels_info": {
+                "label_to_match":"wpa_name",
+                 "labels_to_get": ["{{ join "\",\"" .Values.labelsAsTags }}"]
+                }
+              }
+              {{- end }}
           }]
     spec:
     {{- with .Values.imagePullSecrets }}
@@ -55,6 +64,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "watermarkpodautoscaler"
+            {{- if .Values.labelsAsTags }}
+            - name: DD_LABELS_AS_TAGS
+              value: {{ join " " .Values.labelsAsTags | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /metrics

--- a/chart/watermarkpodautoscaler/values.yaml
+++ b/chart/watermarkpodautoscaler/values.yaml
@@ -25,9 +25,7 @@ rbac:
 # Configure the controller to watch all namespaces
 watchAllNamespaces: true
 # Labels to be included as metric tags
-# labelsAsTags:
-#   - label1
-#   - label2
+labelsAsTags: []
 podSecurityContext: {}
 # fsGroup: 2000
 

--- a/chart/watermarkpodautoscaler/values.yaml
+++ b/chart/watermarkpodautoscaler/values.yaml
@@ -24,6 +24,10 @@ rbac:
   create: true
 # Configure the controller to watch all namespaces
 watchAllNamespaces: true
+# Labels to be included as metric tags
+# labelsAsTags:
+#   - label1
+#   - label2
 podSecurityContext: {}
 # fsGroup: 2000
 


### PR DESCRIPTION
### What does this PR do?

Updates chart for configuring labels as metric tags from #57 

### Motivation

Better user experience

### Describe your test plan

Test Datadog prometheus check output (i.e. the tags) for WPA metrics with and without `labelsAsTags` set in values.yaml