### PR TITLE
Updates to info metric

### DIFF
--- a/chart/watermarkpodautoscaler/Chart.yaml
+++ b/chart/watermarkpodautoscaler/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.2.0
 description: Watermark Pod Autoscaler
 name: watermarkpodautoscaler
-version: v0.2.1
+version: v0.2.2

--- a/chart/watermarkpodautoscaler/templates/deployment.yaml
+++ b/chart/watermarkpodautoscaler/templates/deployment.yaml
@@ -25,8 +25,8 @@ spec:
             ,
             "label_joins": {
               "wpa_controller_labels_info": {
-                "label_to_match":"wpa_name",
-                 "labels_to_get": ["{{ join "\",\"" .Values.labelsAsTags }}"]
+                "labels_to_match": ["wpa_name","resource_namespace"],
+                "labels_to_get": ["{{ join "\",\"" .Values.labelsAsTags }}"]
                 }
               }
               {{- end }}

--- a/pkg/controller/watermarkpodautoscaler/metrics.go
+++ b/pkg/controller/watermarkpodautoscaler/metrics.go
@@ -184,7 +184,7 @@ var (
 			Name:      "labels_info",
 			Help:      "Info metric for additional labels to associate to metrics as tags",
 		},
-		append(extraPromLabels, wpaNamePromLabel),
+		append(extraPromLabels, wpaNamePromLabel, resourceNamespacePromLabel),
 	)
 )
 
@@ -229,7 +229,7 @@ func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onl
 		transitionCountdown.Delete(promLabelsForWpa)
 		delete(promLabelsForWpa, transitionPromLabel)
 
-		promLabelsInfo := prometheus.Labels{wpaNamePromLabel: wpa.Name}
+		promLabelsInfo := prometheus.Labels{wpaNamePromLabel: wpa.Name, resourceNamespacePromLabel: wpa.Namespace}
 		for _, eLabel := range extraPromLabels {
 			eLabelValue := wpa.Labels[eLabel]
 			promLabelsInfo[eLabel] = eLabelValue

--- a/pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go
+++ b/pkg/controller/watermarkpodautoscaler/watermarkpodautoscaler_controller.go
@@ -381,7 +381,7 @@ func (r *ReconcileWatermarkPodAutoscaler) reconcileWPA(logger logr.Logger, wpa *
 	replicaEffective.With(prometheus.Labels{wpaNamePromLabel: wpa.Name, resourceNamespacePromLabel: wpa.Namespace, resourceNamePromLabel: wpa.Spec.ScaleTargetRef.Name, resourceKindPromLabel: wpa.Spec.ScaleTargetRef.Kind}).Set(float64(desiredReplicas))
 
 	// add additional labels to info metric
-	promLabels := prometheus.Labels{wpaNamePromLabel: wpa.Name}
+	promLabels := prometheus.Labels{wpaNamePromLabel: wpa.Name, resourceNamespacePromLabel: wpa.Namespace}
 	for _, eLabel := range extraPromLabels {
 		eLabelValue := wpa.Labels[eLabel]
 		promLabels[eLabel] = eLabelValue


### PR DESCRIPTION
### What does this PR do?

Update of #57, also use namespace label for matching and remove `label_to_match` in favor of `labels_to_match`

### Motivation

Better matching to safeguard against WPAs with the same name
Deprecation of `label_to_match` in the [open metrics check](https://github.com/DataDog/integrations-core/blob/8b034772fcacf21284c3bc5b4e92a16f56e0ae6b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py#L468)

### Additional Notes


### Describe your test plan

Similar to #57