### PR TITLE
Add metric_name label to the replicas_scaling_proposal

### DIFF
--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -128,6 +128,7 @@ var (
 			resourceNamespacePromLabel,
 			resourceNamePromLabel,
 			resourceKindPromLabel,
+			metricNamePromLabel,
 		})
 	replicaEffective = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -212,7 +213,6 @@ func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onl
 	}
 
 	if !onlyMetricsSpecific {
-		replicaProposal.Delete(promLabelsForWpa)
 		replicaEffective.Delete(promLabelsForWpa)
 		replicaMin.Delete(promLabelsForWpa)
 		replicaMax.Delete(promLabelsForWpa)
@@ -246,6 +246,7 @@ func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onl
 
 		lowwm.Delete(promLabelsForWpa)
 		lowwmV2.Delete(promLabelsForWpa)
+		replicaProposal.Delete(promLabelsForWpa)
 		highwm.Delete(promLabelsForWpa)
 		highwmV2.Delete(promLabelsForWpa)
 		value.Delete(promLabelsForWpa)


### PR DESCRIPTION
### What does this PR do?

When using several metrics as input, we now expose several Prometheus metrics `replicas_scaling_proposal`.

### Motivation

When using several metrics in input, `replicas_scaling_proposal` only reflects the last one defined in k8s' `spec.metrics`.
