### PR TITLE
Scale replicas by a configurable interval

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_default.go
+++ b/api/v1alpha1/watermarkpodautoscaler_default.go
@@ -18,9 +18,9 @@ const (
 	defaultScaleDownLimitFactor            = 20
 	defaultScaleUpLimitFactor              = 50
 	// Most common use case is to autoscale over avg:kubernetes.cpu.usage, which directly correlates to the # replicas.
-	defaultAlgorithm                    = "absolute"
-	defaultMinReplicas            int32 = 1
-	defaultReplicaScalingInterval int32 = 1
+	defaultAlgorithm                          = "absolute"
+	defaultMinReplicas                  int32 = 1
+	defaultReplicaScalingAbsoluteModulo int32 = 1
 )
 
 // DefaultWatermarkPodAutoscaler sets the default in the WPA
@@ -30,8 +30,8 @@ func DefaultWatermarkPodAutoscaler(wpa *WatermarkPodAutoscaler) *WatermarkPodAut
 	if wpa.Spec.MinReplicas == nil {
 		defaultWPA.Spec.MinReplicas = NewInt32(defaultMinReplicas)
 	}
-	if wpa.Spec.ReplicaScalingInterval == nil {
-		defaultWPA.Spec.ReplicaScalingInterval = NewInt32(defaultReplicaScalingInterval)
+	if wpa.Spec.ReplicaScalingAbsoluteModulo == nil {
+		defaultWPA.Spec.ReplicaScalingAbsoluteModulo = NewInt32(defaultReplicaScalingAbsoluteModulo)
 	}
 	if wpa.Spec.Algorithm == "" {
 		defaultWPA.Spec.Algorithm = defaultAlgorithm

--- a/api/v1alpha1/watermarkpodautoscaler_default.go
+++ b/api/v1alpha1/watermarkpodautoscaler_default.go
@@ -18,8 +18,9 @@ const (
 	defaultScaleDownLimitFactor            = 20
 	defaultScaleUpLimitFactor              = 50
 	// Most common use case is to autoscale over avg:kubernetes.cpu.usage, which directly correlates to the # replicas.
-	defaultAlgorithm         = "absolute"
-	defaultMinReplicas int32 = 1
+	defaultAlgorithm                    = "absolute"
+	defaultMinReplicas            int32 = 1
+	defaultReplicaScalingInterval int32 = 1
 )
 
 // DefaultWatermarkPodAutoscaler sets the default in the WPA
@@ -28,6 +29,9 @@ func DefaultWatermarkPodAutoscaler(wpa *WatermarkPodAutoscaler) *WatermarkPodAut
 
 	if wpa.Spec.MinReplicas == nil {
 		defaultWPA.Spec.MinReplicas = NewInt32(defaultMinReplicas)
+	}
+	if wpa.Spec.ReplicaScalingInterval == nil {
+		defaultWPA.Spec.ReplicaScalingInterval = NewInt32(defaultReplicaScalingInterval)
 	}
 	if wpa.Spec.Algorithm == "" {
 		defaultWPA.Spec.Algorithm = defaultAlgorithm

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -66,6 +66,10 @@ type WatermarkPodAutoscalerSpec struct {
 	// ScaleDownLimitFactor == 0 means that downscaling will not be allowed for the target.
 	ScaleDownLimitFactor *resource.Quantity `json:"scaleDownLimitFactor,omitempty"`
 
+	// Number of replicas to scale by at a time. When set, replicas added or removed must be a multiple of this parameter.
+	// Allows for special scaling patterns, for instance when an application requires a certain number of pods in multiple
+	ReplicaScalingInterval *int32 `json:"replicaScalingInterval,omitempty"`
+
 	// Parameter used to be a float, in order to support the transition seamlessly, we validate that it is ]0;1[ in the code.
 	Tolerance resource.Quantity `json:"tolerance,omitempty"`
 

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -68,6 +68,7 @@ type WatermarkPodAutoscalerSpec struct {
 
 	// Number of replicas to scale by at a time. When set, replicas added or removed must be a multiple of this parameter.
 	// Allows for special scaling patterns, for instance when an application requires a certain number of pods in multiple
+	// +kubebuilder:validation:Minimum=1
 	ReplicaScalingInterval *int32 `json:"replicaScalingInterval,omitempty"`
 
 	// Parameter used to be a float, in order to support the transition seamlessly, we validate that it is ]0;1[ in the code.

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -69,7 +69,7 @@ type WatermarkPodAutoscalerSpec struct {
 	// Number of replicas to scale by at a time. When set, replicas added or removed must be a multiple of this parameter.
 	// Allows for special scaling patterns, for instance when an application requires a certain number of pods in multiple
 	// +kubebuilder:validation:Minimum=1
-	ReplicaScalingInterval *int32 `json:"replicaScalingInterval,omitempty"`
+	ReplicaScalingAbsoluteModulo *int32 `json:"replicaScalingAbsoluteModulo,omitempty"`
 
 	// Parameter used to be a float, in order to support the transition seamlessly, we validate that it is ]0;1[ in the code.
 	Tolerance resource.Quantity `json:"tolerance,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -187,6 +187,11 @@ func (in *WatermarkPodAutoscalerSpec) DeepCopyInto(out *WatermarkPodAutoscalerSp
 		x := (*in).DeepCopy()
 		*out = &x
 	}
+	if in.ReplicaScalingInterval != nil {
+		in, out := &in.ReplicaScalingInterval, &out.ReplicaScalingInterval
+		*out = new(int32)
+		**out = **in
+	}
 	out.Tolerance = in.Tolerance.DeepCopy()
 	out.ScaleTargetRef = in.ScaleTargetRef
 	if in.Metrics != nil {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -187,8 +187,8 @@ func (in *WatermarkPodAutoscalerSpec) DeepCopyInto(out *WatermarkPodAutoscalerSp
 		x := (*in).DeepCopy()
 		*out = &x
 	}
-	if in.ReplicaScalingInterval != nil {
-		in, out := &in.ReplicaScalingInterval, &out.ReplicaScalingInterval
+	if in.ReplicaScalingAbsoluteModulo != nil {
+		in, out := &in.ReplicaScalingAbsoluteModulo, &out.ReplicaScalingAbsoluteModulo
 		*out = new(int32)
 		**out = **in
 	}

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -38,7 +38,6 @@ func schema__api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallba
 					"kind": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds\"",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -46,7 +45,6 @@ func schema__api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallba
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -75,7 +73,6 @@ func schema__api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) com
 					"metricName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "metricName is the name of the metric in question.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -115,7 +112,6 @@ func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAP
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "type is the type of metric source.  It should be one of \"Object\", \"Pods\" or \"Resource\", each mapping to a matching field in the object.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -151,7 +147,6 @@ func schema__api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) com
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the name of the resource in question.",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -204,20 +199,17 @@ func schema__api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) c
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("./api/v1alpha1.WatermarkPodAutoscalerSpec"),
+							Ref: ref("./api/v1alpha1.WatermarkPodAutoscalerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("./api/v1alpha1.WatermarkPodAutoscalerStatus"),
+							Ref: ref("./api/v1alpha1.WatermarkPodAutoscalerStatus"),
 						},
 					},
 				},
@@ -270,7 +262,6 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 					"tolerance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameter used to be a float, in order to support the transition seamlessly, we validate that it is ]0;1[ in the code.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 						},
 					},
@@ -291,7 +282,6 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 					"scaleTargetRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "part of HorizontalPodAutoscalerSpec, see comments in the k8s-1.10.8 repo: staging/src/k8s.io/api/autoscaling/v1/types.go reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("./api/v1alpha1.CrossVersionObjectReference"),
 						},
 					},
@@ -307,8 +297,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("./api/v1alpha1.MetricSpec"),
+										Ref: ref("./api/v1alpha1.MetricSpec"),
 									},
 								},
 							},
@@ -361,16 +350,14 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallb
 					},
 					"currentReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "int32",
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 					"desiredReplicas": {
 						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "int32",
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 					"currentMetrics": {
@@ -384,8 +371,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/autoscaling/v2beta1.MetricStatus"),
+										Ref: ref("k8s.io/api/autoscaling/v2beta1.MetricStatus"),
 									},
 								},
 							},
@@ -402,8 +388,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/autoscaling/v2beta1.HorizontalPodAutoscalerCondition"),
+										Ref: ref("k8s.io/api/autoscaling/v2beta1.HorizontalPodAutoscalerCondition"),
 									},
 								},
 							},

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -18,17 +18,17 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./api/v1alpha1.CrossVersionObjectReference":  schema__api_v1alpha1_CrossVersionObjectReference(ref),
-		"./api/v1alpha1.ExternalMetricSource":         schema__api_v1alpha1_ExternalMetricSource(ref),
-		"./api/v1alpha1.MetricSpec":                   schema__api_v1alpha1_MetricSpec(ref),
-		"./api/v1alpha1.ResourceMetricSource":         schema__api_v1alpha1_ResourceMetricSource(ref),
-		"./api/v1alpha1.WatermarkPodAutoscaler":       schema__api_v1alpha1_WatermarkPodAutoscaler(ref),
-		"./api/v1alpha1.WatermarkPodAutoscalerSpec":   schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref),
-		"./api/v1alpha1.WatermarkPodAutoscalerStatus": schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference":  schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectReference(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource":         schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec":                   schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource":         schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscaler":       schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec":   schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSpec(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus": schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerStatus(ref),
 	}
 }
 
-func schema__api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -65,7 +65,7 @@ func schema__api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallba
 	}
 }
 
-func schema__api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -105,7 +105,7 @@ func schema__api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) com
 	}
 }
 
-func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -123,13 +123,13 @@ func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAP
 					"external": {
 						SchemaProps: spec.SchemaProps{
 							Description: "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
-							Ref:         ref("./api/v1alpha1.ExternalMetricSource"),
+							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-							Ref:         ref("./api/v1alpha1.ResourceMetricSource"),
+							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource"),
 						},
 					},
 				},
@@ -137,11 +137,11 @@ func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAP
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ExternalMetricSource", "./api/v1alpha1.ResourceMetricSource"},
+			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource"},
 	}
 }
 
-func schema__api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -181,7 +181,7 @@ func schema__api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) com
 	}
 }
 
-func schema__api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -224,11 +224,11 @@ func schema__api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) c
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.WatermarkPodAutoscalerSpec", "./api/v1alpha1.WatermarkPodAutoscalerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -258,6 +258,13 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 						SchemaProps: spec.SchemaProps{
 							Description: "Percentage of replicas that can be removed in an downscale event. Parameter used to be a float, in order to support the transition seamlessly, we validate that it is [0;100[ in the code. ScaleDownLimitFactor == 0 means that downscaling will not be allowed for the target.",
 							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+						},
+					},
+					"replicaScalingInterval": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Number of replicas to scale by at a time. When set, replicas added or removed must be a multiple of this parameter. Allows for special scaling patterns, for instance when an application requires a certain number of pods in multiple",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"tolerance": {
@@ -330,11 +337,11 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.CrossVersionObjectReference", "./api/v1alpha1.MetricSpec", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
+			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
 	}
 }
 
-func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -18,17 +18,17 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference":  schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectReference(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource":         schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec":                   schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource":         schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscaler":       schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec":   schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSpec(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus": schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerStatus(ref),
+		"./api/v1alpha1.CrossVersionObjectReference":  schema__api_v1alpha1_CrossVersionObjectReference(ref),
+		"./api/v1alpha1.ExternalMetricSource":         schema__api_v1alpha1_ExternalMetricSource(ref),
+		"./api/v1alpha1.MetricSpec":                   schema__api_v1alpha1_MetricSpec(ref),
+		"./api/v1alpha1.ResourceMetricSource":         schema__api_v1alpha1_ResourceMetricSource(ref),
+		"./api/v1alpha1.WatermarkPodAutoscaler":       schema__api_v1alpha1_WatermarkPodAutoscaler(ref),
+		"./api/v1alpha1.WatermarkPodAutoscalerSpec":   schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref),
+		"./api/v1alpha1.WatermarkPodAutoscalerStatus": schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref),
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -65,7 +65,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectRefere
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -105,7 +105,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -123,13 +123,13 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref common.Re
 					"external": {
 						SchemaProps: spec.SchemaProps{
 							Description: "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
-							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource"),
+							Ref:         ref("./api/v1alpha1.ExternalMetricSource"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource"),
+							Ref:         ref("./api/v1alpha1.ResourceMetricSource"),
 						},
 					},
 				},
@@ -137,11 +137,11 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref common.Re
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource"},
+			"./api/v1alpha1.ExternalMetricSource", "./api/v1alpha1.ResourceMetricSource"},
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -181,7 +181,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -224,11 +224,11 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(r
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./api/v1alpha1.WatermarkPodAutoscalerSpec", "./api/v1alpha1.WatermarkPodAutoscalerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -260,7 +260,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSp
 							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 						},
 					},
-					"replicaScalingInterval": {
+					"replicaScalingAbsoluteModulo": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Number of replicas to scale by at a time. When set, replicas added or removed must be a multiple of this parameter. Allows for special scaling patterns, for instance when an application requires a certain number of pods in multiple",
 							Type:        []string{"integer"},
@@ -337,11 +337,11 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSp
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
+			"./api/v1alpha1.CrossVersionObjectReference", "./api/v1alpha1.MetricSpec", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd.yaml
+++ b/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd.yaml
@@ -155,7 +155,7 @@ spec:
               format: int32
               minimum: 1
               type: integer
-            replicaScalingInterval:
+            replicaScalingAbsoluteModulo:
               description: The number of replicas to scale up or down by at a time.
               format: int32
               minimum: 1

--- a/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd.yaml
+++ b/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd.yaml
@@ -155,6 +155,11 @@ spec:
               format: int32
               minimum: 1
               type: integer
+            replicaScalingInterval:
+              description: The number of replicas to scale up or down by at a time.
+              format: int32
+              minimum: 1
+              type: integer
             scaleDownLimitFactor:
               description: Percentage of replicas that can be added in an upscale
                 event. Max value will set the limit at the Maximum number of Replicas.

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -238,12 +238,13 @@ spec:
               format: int32
               minimum: 1
               type: integer
-            replicaScalingInterval:
+            replicaScalingAbsoluteModulo:
               description: Number of replicas to scale by at a time. When set, replicas
                 added or removed must be a multiple of this parameter. Allows for
                 special scaling patterns, for instance when an application requires
-                a certain number of pods in multiple AZ's.
+                a certain number of pods in multiple
               format: int32
+              minimum: 1
               type: integer
             scaleDownLimitFactor:
               anyOf:

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -238,6 +238,13 @@ spec:
               format: int32
               minimum: 1
               type: integer
+            replicaScalingInterval:
+              description: Number of replicas to scale by at a time. When set, replicas
+                added or removed must be a multiple of this parameter. Allows for
+                special scaling patterns, for instance when an application requires
+                a certain number of pods in multiple AZ's.
+              format: int32
+              type: integer
             scaleDownLimitFactor:
               anyOf:
               - type: integer

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -187,9 +187,9 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 	switch {
 	case adjustedUsage > adjustedHM:
 		replicaCount = int32(math.Ceil(float64(currentReadyReplicas) * adjustedUsage / (float64(highMark.MilliValue()))))
-		// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingInterval.
-		if replicaScalingIntervalRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingInterval))); replicaScalingIntervalRemainder > 0 {
-			replicaCount += *wpa.Spec.ReplicaScalingInterval - replicaScalingIntervalRemainder
+		// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingAbsoluteModulo.
+		if replicaScalingAbsoluteModuloRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingAbsoluteModulo))); replicaScalingAbsoluteModuloRemainder > 0 {
+			replicaCount += *wpa.Spec.ReplicaScalingAbsoluteModulo - replicaScalingAbsoluteModuloRemainder
 		}
 		// tolerance: milliValue/10 to represent the %.
 		logger.Info("Value is above highMark", "usage", utilizationQuantity.String(), "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "tolerance (%):", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedHM", adjustedHM, "adjustedUsage", adjustedUsage)
@@ -197,9 +197,9 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 		replicaCount = int32(math.Floor(float64(currentReadyReplicas) * adjustedUsage / (float64(lowMark.MilliValue()))))
 		// Keep a minimum of 1 replica
 		replicaCount = int32(math.Max(float64(replicaCount), 1))
-		if replicaScalingIntervalRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingInterval))); replicaScalingIntervalRemainder > 0 {
-			// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingInterval.
-			replicaCount += *wpa.Spec.ReplicaScalingInterval - replicaScalingIntervalRemainder
+		if replicaScalingAbsoluteModuloRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingAbsoluteModulo))); replicaScalingAbsoluteModuloRemainder > 0 {
+			// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingAbsoluteModulo.
+			replicaCount += *wpa.Spec.ReplicaScalingAbsoluteModulo - replicaScalingAbsoluteModuloRemainder
 		}
 		logger.Info("Value is below lowMark", "usage", utilizationQuantity.String(), "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "tolerance (%):", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedLM", adjustedLM, "adjustedUsage", adjustedUsage)
 	default:

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -187,12 +187,20 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 	switch {
 	case adjustedUsage > adjustedHM:
 		replicaCount = int32(math.Ceil(float64(currentReadyReplicas) * adjustedUsage / (float64(highMark.MilliValue()))))
+		// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingInterval.
+		if replicaScalingIntervalRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingInterval))); replicaScalingIntervalRemainder > 0 {
+			replicaCount += *wpa.Spec.ReplicaScalingInterval - replicaScalingIntervalRemainder
+		}
 		// tolerance: milliValue/10 to represent the %.
 		logger.Info("Value is above highMark", "usage", utilizationQuantity.String(), "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "tolerance (%):", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedHM", adjustedHM, "adjustedUsage", adjustedUsage)
 	case adjustedUsage < adjustedLM:
 		replicaCount = int32(math.Floor(float64(currentReadyReplicas) * adjustedUsage / (float64(lowMark.MilliValue()))))
 		// Keep a minimum of 1 replica
 		replicaCount = int32(math.Max(float64(replicaCount), 1))
+		if replicaScalingIntervalRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingInterval))); replicaScalingIntervalRemainder > 0 {
+			// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingInterval.
+			replicaCount += *wpa.Spec.ReplicaScalingInterval - replicaScalingIntervalRemainder
+		}
 		logger.Info("Value is below lowMark", "usage", utilizationQuantity.String(), "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "tolerance (%):", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedLM", adjustedLM, "adjustedUsage", adjustedUsage)
 	default:
 		restrictedScaling.With(labelsWithReason).Set(1)

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -364,7 +364,7 @@ func TestReplicaCalcAbsoluteScaleUp(t *testing.T) {
 }
 
 func TestScaleIntervalReplicaCalcAbsoluteScaleUp(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
+	logf.SetLogger(zap.New())
 	metric1 := v1alpha1.MetricSpec{
 		Type: v1alpha1.ResourceMetricSourceType,
 		Resource: &v1alpha1.ResourceMetricSource{
@@ -396,7 +396,7 @@ func TestScaleIntervalReplicaCalcAbsoluteScaleUp(t *testing.T) {
 }
 
 func TestScaleIntervalReplicaCalcNoScale(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
+	logf.SetLogger(zap.New())
 	metric1 := v1alpha1.MetricSpec{
 		Type: v1alpha1.ResourceMetricSourceType,
 		Resource: &v1alpha1.ResourceMetricSource{
@@ -460,7 +460,7 @@ func TestReplicaCalcAbsoluteScaleDown(t *testing.T) {
 }
 
 func TestScaleIntervalReplicaCalcAbsoluteScaleDown(t *testing.T) {
-	logf.SetLogger(logf.ZapLogger(true))
+	logf.SetLogger(zap.New())
 	metric1 := v1alpha1.MetricSpec{
 		Type: v1alpha1.ResourceMetricSourceType,
 		Resource: &v1alpha1.ResourceMetricSource{

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -440,7 +440,7 @@ func TestScaleIntervalReplicaCalcAbsoluteScaleDown(t *testing.T) {
 	}
 
 	tc := replicaCalcTestCase{
-		expectedReplicas: 2,
+		expectedReplicas: 2, // Replica scaling interval is 2, so we can't scale down to 1 replica even though that is our min.
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -303,10 +303,10 @@ func TestReplicaCalcDisjointResourcesMetrics(t *testing.T) {
 		expectedError: fmt.Errorf("no metrics returned from resource metrics API"),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		scale: makeScale(testDeploymentName, 1, map[string]string{"name": "test-pod"}),
@@ -348,10 +348,10 @@ func TestReplicaCalcAbsoluteScaleUp(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -380,10 +380,10 @@ func TestScaleIntervalReplicaCalcAbsoluteScaleUp(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(5),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(5),
 			},
 		},
 		metric: &metricInfo{
@@ -412,10 +412,10 @@ func TestScaleIntervalReplicaCalcNoScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(5),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(5),
 			},
 		},
 		metric: &metricInfo{
@@ -444,10 +444,10 @@ func TestReplicaCalcAbsoluteScaleDown(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -476,10 +476,10 @@ func TestScaleIntervalReplicaCalcAbsoluteScaleDown(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(2),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(2),
 			},
 		},
 		metric: &metricInfo{
@@ -508,10 +508,10 @@ func TestReplicaCalcAbsoluteScaleDownLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -543,10 +543,10 @@ func TestReplicaCalcAbsoluteScaleUpPendingLessScale(t *testing.T) {
 				// With the absolute algorithm, we will have a utilization of 120k compared to a HWM of 48k (inc. tolerance)
 				// There are 2 Running replicas.
 				// The resulting amount of replicas is 2 * 120 / 40 -> 6
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodRunning, corev1.PodRunning},
@@ -576,10 +576,10 @@ func TestReplicaCalcAbsoluteScaleUpPendingLessScaleExtraReplica(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodRunning, corev1.PodRunning},
@@ -609,10 +609,10 @@ func TestReplicaCalcAbsoluteScaleUpPendingNoScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -642,10 +642,10 @@ func TestReplicaCalcAbsoluteScaleUpPendingNoScaleStretchTolerance(t *testing.T) 
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -675,10 +675,10 @@ func TestReplicaCalcAbsoluteScaleUpFailedLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodFailed, corev1.PodRunning, corev1.PodRunning},
@@ -708,11 +708,11 @@ func TestReplicaCalcAbsoluteScaleUpUnreadyLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReadinessDelaySeconds:  readinessDelay,
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReadinessDelaySeconds:        readinessDelay,
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podCondition: []corev1.PodCondition{
@@ -755,10 +755,10 @@ func TestReplicaCalcAverageScaleUp(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -787,10 +787,10 @@ func TestReplicaCalcAverageScaleDown(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -819,10 +819,10 @@ func TestReplicaCalcAverageScaleDownLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -851,10 +851,10 @@ func TestReplicaCalcAverageScaleUpPendingLessScale(t *testing.T) {
 		expectedReplicas: 3,
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodRunning, corev1.PodRunning},
@@ -884,10 +884,10 @@ func TestReplicaCalcAverageScaleUpPendingNoScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -917,10 +917,10 @@ func TestReplicaCalcAverageScaleUpPendingNoScaleStretchTolerance(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -950,10 +950,10 @@ func TestReplicaCalcAverageScaleUpFailedLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodFailed, corev1.PodRunning, corev1.PodRunning},
@@ -984,11 +984,11 @@ func TestReplicaCalcAverageScaleUpUnreadyLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReadinessDelaySeconds:  readinessDelay,
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReadinessDelaySeconds:        readinessDelay,
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podCondition: []corev1.PodCondition{
@@ -1038,10 +1038,10 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale1(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1070,10 +1070,10 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale2(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 9, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1103,10 +1103,10 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale3(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 20, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1136,10 +1136,10 @@ func TestReplicaCalcWithinAbsoluteExternal(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 9, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(200, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(200, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1173,10 +1173,10 @@ func TestReplicaCalcBelowAverageExternal_Downscale1(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 5, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1206,10 +1206,10 @@ func TestReplicaCalcBelowAverageExternal_Downscale2(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1239,10 +1239,10 @@ func TestReplicaCalcBelowAverageExternal_Downscale3(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1272,10 +1272,10 @@ func TestPendingtExpiredScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodRunning, corev1.PodRunning},
@@ -1310,11 +1310,11 @@ func TestPendingNotExpiredScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				ReadinessDelaySeconds:  readinessDelay,
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				ReadinessDelaySeconds:        readinessDelay,
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1366,11 +1366,11 @@ func TestPendingExpiredHigherWatermarkDownscale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				ReadinessDelaySeconds:  readinessDelay,
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				ReadinessDelaySeconds:        readinessDelay,
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1423,11 +1423,11 @@ func TestPendingNotExpiredWithinBoundsNoScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				ReadinessDelaySeconds:  readinessDelay,
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				ReadinessDelaySeconds:        readinessDelay,
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1479,11 +1479,11 @@ func TestPendingNotOverlyScaling(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 7, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "absolute",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				ReadinessDelaySeconds:  readinessDelay,
-				Metrics:                []v1alpha1.MetricSpec{wpaMetricSpec},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				ReadinessDelaySeconds:        readinessDelay,
+				Metrics:                      []v1alpha1.MetricSpec{wpaMetricSpec},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1555,9 +1555,9 @@ func TestPendingUnprotectedOverlyScaling(t *testing.T) {
 				Algorithm: "absolute",
 				Tolerance: *resource.NewMilliQuantity(10, resource.DecimalSI),
 				// High to force the consideration of pending pods as running
-				ReadinessDelaySeconds:  6000,
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				ReadinessDelaySeconds:        6000,
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1622,10 +1622,10 @@ func TestReplicaCalcBelowAverageExternal_Downscale4(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:              "average",
-				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:                []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+				Algorithm:                    "average",
+				Tolerance:                    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -303,9 +303,10 @@ func TestReplicaCalcDisjointResourcesMetrics(t *testing.T) {
 		expectedError: fmt.Errorf("no metrics returned from resource metrics API"),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		scale: makeScale(testDeploymentName, 1, map[string]string{"name": "test-pod"}),
@@ -347,9 +348,42 @@ func TestReplicaCalcAbsoluteScaleUp(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+			},
+		},
+		metric: &metricInfo{
+			spec:                metric1,
+			levels:              []int64{90000, 90000, 90000}, // We are higher than the HighWatermark
+			expectedUtilization: 270000,
+		},
+	}
+	tc.runTest(t)
+}
+
+func TestScaleIntervalReplicaCalcAbsoluteScaleUp(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	metric1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ResourceMetricSourceType,
+		Resource: &v1alpha1.ResourceMetricSource{
+			Name:           corev1.ResourceCPU,
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "test-pod"}},
+			HighWatermark:  resource.NewMilliQuantity(40000, resource.DecimalSI),
+			LowWatermark:   resource.NewMilliQuantity(20000, resource.DecimalSI),
+		},
+	}
+
+	tc := replicaCalcTestCase{
+		expectedReplicas: 25, // 21 should be computed, but we round it up to the nearest interval of 5.
+		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		wpa: &v1alpha1.WatermarkPodAutoscaler{
+			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(5),
 			},
 		},
 		metric: &metricInfo{
@@ -378,9 +412,42 @@ func TestReplicaCalcAbsoluteScaleDown(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
+			},
+		},
+		metric: &metricInfo{
+			spec:                metric1,
+			levels:              []int64{4000, 4000, 4000}, // We are below the LowWatermark
+			expectedUtilization: 12000,
+		},
+	}
+	tc.runTest(t)
+}
+
+func TestScaleIntervalReplicaCalcAbsoluteScaleDown(t *testing.T) {
+	logf.SetLogger(logf.ZapLogger(true))
+	metric1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ResourceMetricSourceType,
+		Resource: &v1alpha1.ResourceMetricSource{
+			Name:           corev1.ResourceCPU,
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "test-pod"}},
+			HighWatermark:  resource.NewMilliQuantity(40000, resource.DecimalSI),
+			LowWatermark:   resource.NewMilliQuantity(20000, resource.DecimalSI),
+		},
+	}
+
+	tc := replicaCalcTestCase{
+		expectedReplicas: 2,
+		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		wpa: &v1alpha1.WatermarkPodAutoscaler{
+			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(2),
 			},
 		},
 		metric: &metricInfo{
@@ -409,9 +476,10 @@ func TestReplicaCalcAbsoluteScaleDownLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -443,9 +511,10 @@ func TestReplicaCalcAbsoluteScaleUpPendingLessScale(t *testing.T) {
 				// With the absolute algorithm, we will have a utilization of 120k compared to a HWM of 48k (inc. tolerance)
 				// There are 2 Running replicas.
 				// The resulting amount of replicas is 2 * 120 / 40 -> 6
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodRunning, corev1.PodRunning},
@@ -475,9 +544,10 @@ func TestReplicaCalcAbsoluteScaleUpPendingLessScaleExtraReplica(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodRunning, corev1.PodRunning},
@@ -507,9 +577,10 @@ func TestReplicaCalcAbsoluteScaleUpPendingNoScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -539,9 +610,10 @@ func TestReplicaCalcAbsoluteScaleUpPendingNoScaleStretchTolerance(t *testing.T) 
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -571,9 +643,10 @@ func TestReplicaCalcAbsoluteScaleUpFailedLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodFailed, corev1.PodRunning, corev1.PodRunning},
@@ -603,10 +676,11 @@ func TestReplicaCalcAbsoluteScaleUpUnreadyLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:             "absolute",
-				Tolerance:             *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:               []v1alpha1.MetricSpec{metric1},
-				ReadinessDelaySeconds: readinessDelay,
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReadinessDelaySeconds:  readinessDelay,
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podCondition: []corev1.PodCondition{
@@ -649,9 +723,10 @@ func TestReplicaCalcAverageScaleUp(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -680,9 +755,10 @@ func TestReplicaCalcAverageScaleDown(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -711,9 +787,10 @@ func TestReplicaCalcAverageScaleDownLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -742,9 +819,10 @@ func TestReplicaCalcAverageScaleUpPendingLessScale(t *testing.T) {
 		expectedReplicas: 3,
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodRunning, corev1.PodRunning},
@@ -774,9 +852,10 @@ func TestReplicaCalcAverageScaleUpPendingNoScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -806,9 +885,10 @@ func TestReplicaCalcAverageScaleUpPendingNoScaleStretchTolerance(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -838,9 +918,10 @@ func TestReplicaCalcAverageScaleUpFailedLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodFailed, corev1.PodRunning, corev1.PodRunning},
@@ -871,10 +952,11 @@ func TestReplicaCalcAverageScaleUpUnreadyLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:             "average",
-				Tolerance:             *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:               []v1alpha1.MetricSpec{metric1},
-				ReadinessDelaySeconds: readinessDelay,
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReadinessDelaySeconds:  readinessDelay,
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podCondition: []corev1.PodCondition{
@@ -924,9 +1006,10 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale1(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -955,9 +1038,10 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale2(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 9, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -987,9 +1071,10 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale3(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 20, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1019,9 +1104,10 @@ func TestReplicaCalcWithinAbsoluteExternal(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 9, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(200, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(200, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1055,9 +1141,10 @@ func TestReplicaCalcBelowAverageExternal_Downscale1(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 5, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1087,9 +1174,10 @@ func TestReplicaCalcBelowAverageExternal_Downscale2(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1119,9 +1207,10 @@ func TestReplicaCalcBelowAverageExternal_Downscale3(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{
@@ -1151,9 +1240,10 @@ func TestPendingtExpiredScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "absolute",
-				Tolerance: *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodRunning, corev1.PodRunning},
@@ -1188,10 +1278,11 @@ func TestPendingNotExpiredScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:             "absolute",
-				Tolerance:             *resource.NewMilliQuantity(10, resource.DecimalSI),
-				ReadinessDelaySeconds: readinessDelay,
-				Metrics:               []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				ReadinessDelaySeconds:  readinessDelay,
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1243,10 +1334,11 @@ func TestPendingExpiredHigherWatermarkDownscale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:             "absolute",
-				Tolerance:             *resource.NewMilliQuantity(10, resource.DecimalSI),
-				ReadinessDelaySeconds: readinessDelay,
-				Metrics:               []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				ReadinessDelaySeconds:  readinessDelay,
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1299,10 +1391,11 @@ func TestPendingNotExpiredWithinBoundsNoScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:             "absolute",
-				Tolerance:             *resource.NewMilliQuantity(10, resource.DecimalSI),
-				ReadinessDelaySeconds: readinessDelay,
-				Metrics:               []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				ReadinessDelaySeconds:  readinessDelay,
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1354,10 +1447,11 @@ func TestPendingNotOverlyScaling(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 7, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:             "absolute",
-				Tolerance:             *resource.NewMilliQuantity(10, resource.DecimalSI),
-				ReadinessDelaySeconds: readinessDelay,
-				Metrics:               []v1alpha1.MetricSpec{wpaMetricSpec},
+				Algorithm:              "absolute",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				ReadinessDelaySeconds:  readinessDelay,
+				Metrics:                []v1alpha1.MetricSpec{wpaMetricSpec},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1429,8 +1523,9 @@ func TestPendingUnprotectedOverlyScaling(t *testing.T) {
 				Algorithm: "absolute",
 				Tolerance: *resource.NewMilliQuantity(10, resource.DecimalSI),
 				// High to force the consideration of pending pods as running
-				ReadinessDelaySeconds: 6000,
-				Metrics:               []v1alpha1.MetricSpec{metric1},
+				ReadinessDelaySeconds:  6000,
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase: []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodRunning},
@@ -1495,9 +1590,10 @@ func TestReplicaCalcBelowAverageExternal_Downscale4(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm: "average",
-				Tolerance: *resource.NewMilliQuantity(10, resource.DecimalSI),
-				Metrics:   []v1alpha1.MetricSpec{metric1},
+				Algorithm:              "average",
+				Tolerance:              *resource.NewMilliQuantity(10, resource.DecimalSI),
+				Metrics:                []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingInterval: v1alpha1.NewInt32(1),
 			},
 		},
 		metric: &metricInfo{


### PR DESCRIPTION
### What does this PR do?

This change exposes a new configuration option, `ReplicaScaleInterval` which controls how many replicas will be added at a time. When calculating the desired replicas, we use the existing algorithm to determine the desired number of replicas, and then we round _up_ to the nearest `ReplicaScaleInterval`. 

I didn't touch the interaction with the maxReplicas at all, so if your `maxReplicas` value is not divisble by the `ReplicaScaleInterval`, the max will win. 

### Motivation

I want to use WPA with kafka, with a specific number of replicas at any given moment. This change would allow us to always have a number of replicas that is divisible by 3, 5, etc.

### Additional Notes

The churn in `api/v1alpha1/zz_generated.openapi.go` doesn't seem quite right to me, I ran `make generate` and that came out. 

I want this to have a default value of 1, so that no behavior changes with this change unless you explicitly set a new value. That's my understanding of what `api/v1alpha1/watermarkpodautoscaler_default.go` does, but I'm not 100% sure since I needed to specify a value in the tests. Maybe that's just how the tests are setup.

### Describe your test plan

Please let me know if I should add any additional tests! 
