### PR TITLE
Fix ReplicaScalingAbsoluteModulo defaulting

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_default.go
+++ b/api/v1alpha1/watermarkpodautoscaler_default.go
@@ -75,6 +75,9 @@ func IsDefaultWatermarkPodAutoscaler(wpa *WatermarkPodAutoscaler) bool {
 	if wpa.Spec.DownscaleForbiddenWindowSeconds == 0 {
 		return false
 	}
+	if wpa.Spec.ReplicaScalingAbsoluteModulo == nil {
+		return false
+	}
 	if wpa.Spec.UpscaleForbiddenWindowSeconds == 0 {
 		return false
 	}
@@ -89,7 +92,7 @@ func CheckWPAValidity(wpa *WatermarkPodAutoscaler) error {
 		return fmt.Errorf(msg)
 	}
 	if wpa.Spec.MinReplicas == nil || wpa.Spec.MaxReplicas < *wpa.Spec.MinReplicas {
-		msg := fmt.Sprintf("watermark pod autoscaler requires the minimum number of replicas to be configured and inferior to the maximum")
+		msg := "watermark pod autoscaler requires the minimum number of replicas to be configured and inferior to the maximum"
 		return fmt.Errorf(msg)
 	}
 	if wpa.Spec.Tolerance.MilliValue() > 1000 || wpa.Spec.Tolerance.MilliValue() < 0 {


### PR DESCRIPTION
### What does this PR do?

Fix the function `IsDefaultWatermarkPodAutoscaler()` to detect if `spec.replicaScalingAbsoluteModulo` is not set. if it is note set, set it to `1` (default value)

### Motivation

Runtime panic in `v0.3.0-rc.3` due to a missing `spec.ReplicaScalingAbsoluteModulo` defaulting verification.

```console
{"level":"info","ts":1620737770.780118,"logger":"controllers.WatermarkPodAutoscaler","msg":"Metrics from the External Metrics Provider","watermarkpodautoscaler":"datadog-agent/example-watermarkpodautoscaler","metrics":[1780200]}
E0511 14:56:10.780253   13085 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 284 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x236c060, 0x31ba230)
	/Users/cedric.lamoriniere/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/Users/cedric.lamoriniere/go/pkg/mod/k8s.io/apimachinery@v0.20.2/pkg/util/runtime/runtime.go:48 +0x86
panic(0x236c060, 0x31ba230)
	/usr/local/Cellar/go/1.16.3/libexec/src/runtime/panic.go:965 +0x1b9
github.com/DataDog/watermarkpodautoscaler/controllers.getReplicaCount(0x278f588, 0xc000124d30, 0x500000005, 0xc000640240, 0xc00052b4d0, 0x2d, 0x413b29e800000000, 0xc0007b9780, 0xc0007b9740, 0x1, ...)
	/Users/cedric.lamoriniere/dev/watermarkpodautoscaler/controllers/replica_calculator.go:191 +0x11bf
github.com/DataDog/watermarkpodautoscaler/controllers.(*ReplicaCalculator).GetExternalMetricReplicas(0xc0005a6b00, 0x278f588, 0xc000124d30, 0xc002350a00, 0xc0007c08e0, 0x8, 0xc00092b5f0, 0x0, 0xc000640240, 0x0, ...)
	/Users/cedric.lamoriniere/dev/watermarkpodautoscaler/controllers/replica_calculator.go:107 +0x419
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
