### PR TITLE
Fix WPA dry-run status in kubectl output

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -21,7 +21,7 @@ import (
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="min replicas",type="integer",JSONPath=".spec.minReplicas"
 // +kubebuilder:printcolumn:name="max replicas",type="integer",JSONPath=".spec.maxReplicas"
-// +kubebuilder:printcolumn:name="dry-run",type="string",JSONPath=".spec.dryRun"
+// +kubebuilder:printcolumn:name="dry-run",type="string",JSONPath=".status.conditions[?(@.type==\"DryRun\")].status"
 // +kubebuilder:resource:path=watermarkpodautoscalers,shortName=wpa
 // +k8s:openapi-gen=true
 // +genclient

--- a/bundle/manifests/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/bundle/manifests/datadoghq.com_watermarkpodautoscalers.yaml
@@ -25,7 +25,7 @@ spec:
   - JSONPath: .spec.maxReplicas
     name: max replicas
     type: integer
-  - JSONPath: .spec.dryRun
+  - JSONPath: .status.conditions[?(@.type=="DryRun")].status
     name: dry-run
     type: string
   group: datadoghq.com

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -25,7 +25,7 @@ spec:
   - JSONPath: .spec.maxReplicas
     name: max replicas
     type: integer
-  - JSONPath: .spec.dryRun
+  - JSONPath: .status.conditions[?(@.type=="DryRun")].status
     name: dry-run
     type: string
   group: datadoghq.com


### PR DESCRIPTION
### What does this PR do?

Update the ` +kubebuilder:printcolumn` on top of `type WatermarkPodAutoscaler struct `

```golang
// +kubebuilder:printcolumn:name="dry-run",type="string",JSONPath=".status.conditions[?(@.type==\"DryRun\")].status"
// ...
type WatermarkPodAutoscaler struct 
```

### Motivation

Fix WPA dry-run status in kubectl output.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Create a WPA without the dry-run mode. the `dry-run` status with `kubectl get wpa` should be equal to `false`
