### PR TITLE
Fix helm chart for v0.3 release

### DIFF
--- a/chart/watermarkpodautoscaler/templates/deployment.yaml
+++ b/chart/watermarkpodautoscaler/templates/deployment.yaml
@@ -45,8 +45,6 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-          - watermarkpodautoscaler
           args:
             - --zap-level={{ .Values.logLevel }}
             - --leader-election-resource={{ .Values.leaderElectionResourceLock }}

--- a/chart/watermarkpodautoscaler/values.yaml
+++ b/chart/watermarkpodautoscaler/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 image:
   repository: gcr.io/datadoghq/watermarkpodautoscaler
-  tag: v0.3.0-rc6
+  tag: v0.3.0-rc.6
   pullPolicy: IfNotPresent
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
### What does this PR do?

Remove the `command` field in the Deployment manifest.

### Motivation

in v0.3 the controller binary has been renamed from `watermarkpodautoscaler` to `manager`. Since the `CMD` is defined in the dockerfile, the `command` field is not needed in the PodTemplate.

### Additional Notes

N/A

### Describe your test plan

Try to deploy the last RC with the chart present in the `v0.3` branch. the controller should start.
