### PR TITLE
Fix DeploymentConfig support on openshift

### DIFF
--- a/chart/watermarkpodautoscaler/templates/clusterrole.yaml
+++ b/chart/watermarkpodautoscaler/templates/clusterrole.yaml
@@ -11,11 +11,19 @@ rules:
   - extensions
   resources:
   - replicasets/scale
+  - replicationcontrollers/scale
   - deployments/scale
   - statefulsets/scale
   verbs:
   - update
   - get
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs/scale
+  verbs:
+  - 'update'
+  - 'get'
 - apiGroups:
   - ""
   resources:

--- a/chart/watermarkpodautoscaler/templates/role.yaml
+++ b/chart/watermarkpodautoscaler/templates/role.yaml
@@ -57,8 +57,16 @@ rules:
   - extensions
   resources:
   - replicasets/scale
+  - replicationcontrollers/scale
   - deployments/scale
   - statefulsets/scale
+  verbs:
+  - 'update'
+  - 'get'
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs/scale
   verbs:
   - 'update'
   - 'get'

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -51,10 +51,19 @@ rules:
   resources:
   - deployments/scale
   - replicasets/scale
+  - replicationcontrollers/scale
   - statefulsets/scale
   verbs:
   - get
   - update
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -70,12 +70,13 @@ type WatermarkPodAutoscalerReconciler struct {
 }
 
 // +kubebuilder:rbac:groups=apps;extensions,resources=deployments/finalizers,resourceNames=watermarkpodautoscalers,verbs=update
+// +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=datadoghq.com,resources=watermarkpodautoscalers;watermarkpodautoscalers/status,verbs=*
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=create
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,resourceNames=watermarkpodautoscaler-lock,verbs=update;get
-// +kubebuilder:rbac:groups=apps;extensions,resources=replicasets/scale;deployments/scale;statefulsets/scale,verbs=update;get
+// +kubebuilder:rbac:groups=apps;extensions,resources=replicasets/scale;deployments/scale;statefulsets/scale;replicationcontrollers/scale,verbs=update;get
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,resourceNames=watermarkpodautoscaler-lock,verbs=update;get
 


### PR DESCRIPTION
### What does this PR do?

Add missing RBAC to be able to scale specific Openshift resources: `DeploymentConfig` and `ReplicationController`

### Motivation

Fix the support of `DeploymentConfig` on openshift

This should fix #69 

### Additional Notes

N/A

### Describe your test plan

* deploy the wpa controller on openshift.
* create a dummy DeploymentConfig resource
```yaml
apiVersion: v1
kind: DeploymentConfig
metadata:
  name: hello-openshift
spec:
  replicas: 1
  selector:
    app: hello-openshift
  template:
    metadata:
      labels:
        app: hello-openshift
    spec:
      containers:
      - name: hello-openshift
        image: openshift/hello-openshift:latest
        ports:
        - containerPort: 80
  strategy:
    type: Rolling   
```
* create a WPA target this DeploymentConfig
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: WatermarkPodAutoscaler
metadata:
  name: hello-openshift
spec:
  maxReplicas: 10
  minReplicas: 2
  tolerance: 0.01
  readinessDelay: 10
  scaleTargetRef:
    kind: DeploymentConfig
    apiVersion: apps.openshift.io/v1
    name: hello-openshift
  metrics:
  - type: Resource
    resource:
      highWatermark: "300Mi"
      lowWatermark: "50Mi"
      name: memory
      metricSelector:
        matchLabels:
          app: hello-openshift
```

result: the WPA controller should be able to scale the DeploymentConfig to at least the `minReplicas` value which is 3