### PR TITLE
[CI] Switch to helm/kind GH action

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -28,11 +28,10 @@ jobs:
         run: |
           make test
       - name: Setup kind for e2e
-        uses: engineerd/setup-kind@v0.5.0
+        uses: helm/kind-action@v1.2.0
         with:
-          version: "v0.9.0"
           config: test/cluster-kind.yaml
-          name: wpa-e2e-test
+          cluster_name: wpa-e2e-test
       - name: Run e2e tests (kind cluster)
         run: |
           export PATH=$PATH:$(pwd)/bin


### PR DESCRIPTION
### What does this PR do?

Use `helm/kind-action` instead of `engineerd/setup-kind` for e2e GH actions.

### Motivation

Stability.

### Describe your test plan

E2E tests are green.