### PR TITLE
[refactor] Use defined MetricSource types instead of strings

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_default.go
+++ b/api/v1alpha1/watermarkpodautoscaler_default.go
@@ -116,7 +116,7 @@ func checkWPAMetricsValidity(wpa *WatermarkPodAutoscaler) (err error) {
 	// We also make sure that the Watermarks are properly set.
 	for _, metric := range wpa.Spec.Metrics {
 		switch metric.Type {
-		case "External":
+		case ExternalMetricSourceType:
 			if metric.External == nil {
 				return fmt.Errorf("metric.External is nil while metric.Type is '%s'", metric.Type)
 			}
@@ -132,7 +132,7 @@ func checkWPAMetricsValidity(wpa *WatermarkPodAutoscaler) (err error) {
 				msg := fmt.Sprintf("Low WaterMark of External metric %s{%s} has to be strictly inferior to the High Watermark", metric.External.MetricName, metric.External.MetricSelector.MatchLabels)
 				return fmt.Errorf(msg)
 			}
-		case "Resource":
+		case ResourceMetricSourceType:
 			if metric.Resource == nil {
 				return fmt.Errorf("metric.Resource is nil while metric.Type is '%s'", metric.Type)
 			}


### PR DESCRIPTION
### What does this PR do?

Minor refactor.

