### PR TITLE
Add latest condition and latest scale to `kubectl get wpa` output

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -15,6 +15,8 @@ import (
 // WatermarkPodAutoscaler is the Schema for the watermarkpodautoscalers API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="condition",type="string",JSONPath=".status.conditions[0].type"
+// +kubebuilder:printcolumn:name="condition status",type="string",JSONPath=".status.conditions[0].status"
 // +kubebuilder:printcolumn:name="value",type="string",JSONPath=".status.currentMetrics[*].external.currentValue.."
 // +kubebuilder:printcolumn:name="high watermark",type="string",JSONPath=".spec.metrics[*].external.highWatermark.."
 // +kubebuilder:printcolumn:name="low watermark",type="string",JSONPath=".spec.metrics[*].external.lowWatermark.."
@@ -22,6 +24,7 @@ import (
 // +kubebuilder:printcolumn:name="min replicas",type="integer",JSONPath=".spec.minReplicas"
 // +kubebuilder:printcolumn:name="max replicas",type="integer",JSONPath=".spec.maxReplicas"
 // +kubebuilder:printcolumn:name="dry-run",type="string",JSONPath=".status.conditions[?(@.type==\"DryRun\")].status"
+// +kubebuilder:printcolumn:name="last scale",type="date",JSONPath=".status.lastScaleTime"
 // +kubebuilder:resource:path=watermarkpodautoscalers,shortName=wpa
 // +k8s:openapi-gen=true
 // +genclient

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -7,6 +7,12 @@ metadata:
   name: watermarkpodautoscalers.datadoghq.com
 spec:
   additionalPrinterColumns:
+  - JSONPath: .status.conditions[0].type
+    name: condition
+    type: string
+  - JSONPath: .status.conditions[0].status
+    name: condition status
+    type: string
   - JSONPath: .status.currentMetrics[*].external.currentValue..
     name: value
     type: string
@@ -28,6 +34,9 @@ spec:
   - JSONPath: .status.conditions[?(@.type=="DryRun")].status
     name: dry-run
     type: string
+  - JSONPath: .status.lastScaleTime
+    name: last scale
+    type: date
   group: datadoghq.com
   names:
     kind: WatermarkPodAutoscaler

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -559,6 +560,10 @@ func setConditionInList(inputList []autoscalingv2.HorizontalPodAutoscalerConditi
 	existingCond.Status = status
 	existingCond.Reason = reason
 	existingCond.Message = fmt.Sprintf(message, args...)
+
+	sort.Slice(resList, func(i, j int) bool {
+		return resList[i].LastTransitionTime.After(resList[j].LastTransitionTime.Time)
+	})
 
 	return resList
 }


### PR DESCRIPTION
### What does this PR do?

Adds new columns to the `kubectl get wpa` output:
- `condition` ("ScalingActive", "AbleToScale", "ScalingLimited")
- `condition status` (true or false)
- `last scale` (time passed since last scale).

To be able to show the latest condition, I needed to keep them sorted. That's why `kubectl get wpa -o yaml` will now always show them sorted by "LatestTransitionTime" (most recent first).

### Describe your test plan

Deploy an WPA. Check that the 3 new columns mentioned above appear in `kubectl get wpa` and show correct information. For `condition` and `condition status`, you can check that the one shown corresponds to the most recent condition shown in `kubectl get wpa -o yaml`.
