### PR TITLE
Fix CRD definition and validation

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -88,6 +88,7 @@ type WatermarkPodAutoscalerSpec struct {
 	// and will set the desired number of pods by using its Scale subresource.
 	ScaleTargetRef CrossVersionObjectReference `json:"scaleTargetRef"`
 	// specifications that will be used to calculate the desired replica count
+	// +optional
 	// +listType=set
 	Metrics []MetricSpec `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
@@ -184,10 +185,12 @@ type WatermarkPodAutoscalerStatus struct {
 	LastScaleTime      *metav1.Time `json:"lastScaleTime,omitempty"`
 	CurrentReplicas    int32        `json:"currentReplicas"`
 	DesiredReplicas    int32        `json:"desiredReplicas"`
+	// +optional
 	// +listType=set
-	CurrentMetrics []autoscalingv2.MetricStatus `json:"currentMetrics"`
+	CurrentMetrics []autoscalingv2.MetricStatus `json:"currentMetrics,omitempty"`
+	// +optional
 	// +listType=set
-	Conditions []autoscalingv2.HorizontalPodAutoscalerCondition `json:"conditions"`
+	Conditions []autoscalingv2.HorizontalPodAutoscalerCondition `json:"conditions,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -107,6 +107,7 @@ type WatermarkPodAutoscalerSpec struct {
 type ExternalMetricSource struct {
 	// metricName is the name of the metric in question.
 	MetricName string `json:"metricName"`
+
 	// metricSelector is used to identify a specific time series
 	// within a given metric.
 	// +optional
@@ -127,6 +128,7 @@ type ExternalMetricSource struct {
 type ResourceMetricSource struct {
 	// name is the name of the resource in question.
 	Name v1.ResourceName `json:"name"`
+
 	// metricSelector is used to identify a specific time series
 	// within a given metric.
 	// +optional

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -18,17 +18,17 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference":  schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectReference(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource":         schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec":                   schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource":         schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscaler":       schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec":   schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSpec(ref),
-		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus": schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerStatus(ref),
+		"./api/v1alpha1.CrossVersionObjectReference":  schema__api_v1alpha1_CrossVersionObjectReference(ref),
+		"./api/v1alpha1.ExternalMetricSource":         schema__api_v1alpha1_ExternalMetricSource(ref),
+		"./api/v1alpha1.MetricSpec":                   schema__api_v1alpha1_MetricSpec(ref),
+		"./api/v1alpha1.ResourceMetricSource":         schema__api_v1alpha1_ResourceMetricSource(ref),
+		"./api/v1alpha1.WatermarkPodAutoscaler":       schema__api_v1alpha1_WatermarkPodAutoscaler(ref),
+		"./api/v1alpha1.WatermarkPodAutoscalerSpec":   schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref),
+		"./api/v1alpha1.WatermarkPodAutoscalerStatus": schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref),
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -65,7 +65,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectRefere
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -105,7 +105,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -123,13 +123,13 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref common.Re
 					"external": {
 						SchemaProps: spec.SchemaProps{
 							Description: "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
-							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource"),
+							Ref:         ref("./api/v1alpha1.ExternalMetricSource"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource"),
+							Ref:         ref("./api/v1alpha1.ResourceMetricSource"),
 						},
 					},
 				},
@@ -137,11 +137,11 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref common.Re
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource"},
+			"./api/v1alpha1.ExternalMetricSource", "./api/v1alpha1.ResourceMetricSource"},
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -181,7 +181,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -211,24 +211,24 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(r
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec"),
+							Ref:     ref("./api/v1alpha1.WatermarkPodAutoscalerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus"),
+							Ref:     ref("./api/v1alpha1.WatermarkPodAutoscalerStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"./api/v1alpha1.WatermarkPodAutoscalerSpec", "./api/v1alpha1.WatermarkPodAutoscalerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -292,7 +292,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSp
 						SchemaProps: spec.SchemaProps{
 							Description: "part of HorizontalPodAutoscalerSpec, see comments in the k8s-1.10.8 repo: staging/src/k8s.io/api/autoscaling/v1/types.go reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference"),
+							Ref:         ref("./api/v1alpha1.CrossVersionObjectReference"),
 						},
 					},
 					"metrics": {
@@ -308,7 +308,7 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSp
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec"),
+										Ref:     ref("./api/v1alpha1.MetricSpec"),
 									},
 								},
 							},
@@ -337,11 +337,11 @@ func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSp
 			},
 		},
 		Dependencies: []string{
-			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
+			"./api/v1alpha1.CrossVersionObjectReference", "./api/v1alpha1.MetricSpec", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
 	}
 }
 
-func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -18,17 +18,17 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./api/v1alpha1.CrossVersionObjectReference":  schema__api_v1alpha1_CrossVersionObjectReference(ref),
-		"./api/v1alpha1.ExternalMetricSource":         schema__api_v1alpha1_ExternalMetricSource(ref),
-		"./api/v1alpha1.MetricSpec":                   schema__api_v1alpha1_MetricSpec(ref),
-		"./api/v1alpha1.ResourceMetricSource":         schema__api_v1alpha1_ResourceMetricSource(ref),
-		"./api/v1alpha1.WatermarkPodAutoscaler":       schema__api_v1alpha1_WatermarkPodAutoscaler(ref),
-		"./api/v1alpha1.WatermarkPodAutoscalerSpec":   schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref),
-		"./api/v1alpha1.WatermarkPodAutoscalerStatus": schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference":  schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectReference(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource":         schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec":                   schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource":         schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscaler":       schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec":   schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSpec(ref),
+		"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus": schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerStatus(ref),
 	}
 }
 
-func schema__api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -65,7 +65,7 @@ func schema__api_v1alpha1_CrossVersionObjectReference(ref common.ReferenceCallba
 	}
 }
 
-func schema__api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -105,7 +105,7 @@ func schema__api_v1alpha1_ExternalMetricSource(ref common.ReferenceCallback) com
 	}
 }
 
-func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -123,13 +123,13 @@ func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAP
 					"external": {
 						SchemaProps: spec.SchemaProps{
 							Description: "external refers to a global metric that is not associated with any Kubernetes object. It allows autoscaling based on information coming from components running outside of cluster (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster).",
-							Ref:         ref("./api/v1alpha1.ExternalMetricSource"),
+							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource"),
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "resource refers to a resource metric (such as those specified in requests and limits) known to Kubernetes describing each pod in the current scale target (e.g. CPU or memory). Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
-							Ref:         ref("./api/v1alpha1.ResourceMetricSource"),
+							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource"),
 						},
 					},
 				},
@@ -137,11 +137,11 @@ func schema__api_v1alpha1_MetricSpec(ref common.ReferenceCallback) common.OpenAP
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.ExternalMetricSource", "./api/v1alpha1.ResourceMetricSource"},
+			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ExternalMetricSource", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.ResourceMetricSource"},
 	}
 }
 
-func schema__api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -181,7 +181,7 @@ func schema__api_v1alpha1_ResourceMetricSource(ref common.ReferenceCallback) com
 	}
 }
 
-func schema__api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -211,24 +211,24 @@ func schema__api_v1alpha1_WatermarkPodAutoscaler(ref common.ReferenceCallback) c
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("./api/v1alpha1.WatermarkPodAutoscalerSpec"),
+							Ref:     ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("./api/v1alpha1.WatermarkPodAutoscalerStatus"),
+							Ref:     ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.WatermarkPodAutoscalerSpec", "./api/v1alpha1.WatermarkPodAutoscalerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerSpec", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.WatermarkPodAutoscalerStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -292,7 +292,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 						SchemaProps: spec.SchemaProps{
 							Description: "part of HorizontalPodAutoscalerSpec, see comments in the k8s-1.10.8 repo: staging/src/k8s.io/api/autoscaling/v1/types.go reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.",
 							Default:     map[string]interface{}{},
-							Ref:         ref("./api/v1alpha1.CrossVersionObjectReference"),
+							Ref:         ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference"),
 						},
 					},
 					"metrics": {
@@ -308,7 +308,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("./api/v1alpha1.MetricSpec"),
+										Ref:     ref("github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec"),
 									},
 								},
 							},
@@ -337,11 +337,11 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 			},
 		},
 		Dependencies: []string{
-			"./api/v1alpha1.CrossVersionObjectReference", "./api/v1alpha1.MetricSpec", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
+			"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.CrossVersionObjectReference", "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1.MetricSpec", "k8s.io/apimachinery/pkg/api/resource.Quantity"},
 	}
 }
 
-func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_DataDog_watermarkpodautoscaler_api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -410,7 +410,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"currentReplicas", "desiredReplicas", "currentMetrics", "conditions"},
+				Required: []string{"currentReplicas", "desiredReplicas"},
 			},
 		},
 		Dependencies: []string{

--- a/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd.yaml
+++ b/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd.yaml
@@ -1,6 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
   name: watermarkpodautoscalers.datadoghq.com
 spec:
   additionalPrinterColumns:
@@ -66,7 +69,7 @@ spec:
               minimum: 1
               type: integer
             dryRun:
-              description: Wether planned scale changes are actually applied
+              description: Whether planned scale changes are actually applied
               type: boolean
             maxReplicas:
               format: int32
@@ -87,9 +90,15 @@ spec:
                       running outside of cluster).
                     properties:
                       highWatermark:
-                        type: string
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       lowWatermark:
-                        type: string
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       metricName:
                         description: metricName is the name of the metric in question.
                         type: string
@@ -142,6 +151,76 @@ spec:
                     required:
                     - metricName
                     type: object
+                  resource:
+                    description: resource refers to a resource metric (such as those
+                      specified in requests and limits) known to Kubernetes describing
+                      each pod in the current scale target (e.g. CPU or memory). Such
+                      metrics are built in to Kubernetes, and have special scaling
+                      options on top of those available to normal per-pod metrics
+                      using the "pods" source.
+                    properties:
+                      highWatermark:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      lowWatermark:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      metricSelector:
+                        description: metricSelector is used to identify a specific
+                          time series within a given metric.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      name:
+                        description: name is the name of the resource in question.
+                        type: string
+                    required:
+                    - name
+                    type: object
                   type:
                     description: type is the type of metric source.  It should be
                       one of "Object", "Pods" or "Resource", each mapping to a matching
@@ -155,14 +234,27 @@ spec:
               format: int32
               minimum: 1
               type: integer
+            readinessDelaySeconds:
+              format: int32
+              minimum: 1
+              type: integer
             replicaScalingAbsoluteModulo:
-              description: The number of replicas to scale up or down by at a time.
+              description: Number of replicas to scale by at a time. When set, replicas
+                added or removed must be a multiple of this parameter. Allows for
+                special scaling patterns, for instance when an application requires
+                a certain number of pods in multiple
               format: int32
               minimum: 1
               type: integer
             scaleDownLimitFactor:
-              description: Percentage of replicas that can be added in an upscale
-                event. Max value will set the limit at the Maximum number of Replicas.
+              anyOf:
+              - type: integer
+              - type: string
+              description: Percentage of replicas that can be removed in an downscale
+                event. Parameter used to be a float, in order to support the transition
+                seamlessly, we validate that it is [0;100[ in the code. ScaleDownLimitFactor
+                == 0 means that downscaling will not be allowed for the target.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
             scaleTargetRef:
               description: 'part of HorizontalPodAutoscalerSpec, see comments in the
                 k8s-1.10.8 repo: staging/src/k8s.io/api/autoscaling/v1/types.go reference
@@ -184,9 +276,21 @@ spec:
               - name
               type: object
             scaleUpLimitFactor:
+              anyOf:
+              - type: integer
+              - type: string
               description: Percentage of replicas that can be added in an upscale
-                event. Max value will set the limit at the Maximum number of Replicas.
-            tolerance: {}
+                event. Parameter used to be a float, in order to support the transition
+                seamlessly, we validate that it is [0;100] in the code. ScaleUpLimitFactor
+                == 0 means that upscaling will not be allowed for the target.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+            tolerance:
+              anyOf:
+              - type: integer
+              - type: string
+              description: Parameter used to be a float, in order to support the transition
+                seamlessly, we validate that it is ]0;1[ in the code.
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
             upscaleForbiddenWindowSeconds:
               format: int32
               minimum: 1
@@ -232,6 +336,45 @@ spec:
                 description: MetricStatus describes the last-read state of a single
                   metric.
                 properties:
+                  containerResource:
+                    description: container resource refers to a resource metric (such
+                      as those specified in requests and limits) known to Kubernetes
+                      describing a single container in each pod in the current scale
+                      target (e.g. CPU or memory). Such metrics are built in to Kubernetes,
+                      and have special scaling options on top of those available to
+                      normal per-pod metrics using the "pods" source.
+                    properties:
+                      container:
+                        description: container is the name of the container in the
+                          pods of the scaling target
+                        type: string
+                      currentAverageUtilization:
+                        description: currentAverageUtilization is the current value
+                          of the average of the resource metric across all relevant
+                          pods, represented as a percentage of the requested value
+                          of the resource for the pods.  It will only be present if
+                          `targetAverageValue` was set in the corresponding metric
+                          specification.
+                        format: int32
+                        type: integer
+                      currentAverageValue:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: currentAverageValue is the current value of the
+                          average of the resource metric across all relevant pods,
+                          as a raw value (instead of as a percentage of the request),
+                          similar to the "pods" metric source type. It will always
+                          be set, regardless of the corresponding metric specification.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      name:
+                        description: name is the name of the resource in question.
+                        type: string
+                    required:
+                    - container
+                    - currentAverageValue
+                    - name
+                    type: object
                   external:
                     description: external refers to a global metric that is not associated
                       with any Kubernetes object. It allows autoscaling based on information
@@ -240,13 +383,19 @@ spec:
                       running outside of cluster).
                     properties:
                       currentAverageValue:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: currentAverageValue is the current value of metric
                           averaged over autoscaled pods.
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       currentValue:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: currentValue is the current value of the metric
                           (as a quantity)
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       metricName:
                         description: metricName is the name of a metric used for autoscaling
                           in metric system.
@@ -306,13 +455,19 @@ spec:
                       object (for example, hits-per-second on an Ingress object).
                     properties:
                       averageValue:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: averageValue is the current value of the average
                           of the metric across all relevant pods (as a quantity)
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       currentValue:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: currentValue is the current value of the metric
                           (as a quantity).
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       metricName:
                         description: metricName is the name of the metric in question.
                         type: string
@@ -394,9 +549,12 @@ spec:
                       target value.
                     properties:
                       currentAverageValue:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: currentAverageValue is the current value of the
                           average of the metric across all relevant pods (as a quantity)
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       metricName:
                         description: metricName is the name of the metric in question
                         type: string
@@ -471,12 +629,15 @@ spec:
                         format: int32
                         type: integer
                       currentAverageValue:
+                        anyOf:
+                        - type: integer
+                        - type: string
                         description: currentAverageValue is the current value of the
                           average of the resource metric across all relevant pods,
                           as a raw value (instead of as a percentage of the request),
                           similar to the "pods" metric source type. It will always
                           be set, regardless of the corresponding metric specification.
-                        type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       name:
                         description: name is the name of the resource in question.
                         type: string
@@ -485,9 +646,11 @@ spec:
                     - name
                     type: object
                   type:
-                    description: type is the type of metric source.  It will be one
-                      of "Object", "Pods" or "Resource", each corresponds to a matching
-                      field in the object.
+                    description: 'type is the type of metric source.  It will be one
+                      of "ContainerResource", "External", "Object", "Pods" or "Resource",
+                      each corresponds to a matching field in the object. Note: "ContainerResource"
+                      type is available on when the feature-gate HPAContainerMetrics
+                      is enabled'
                     type: string
                 required:
                 - type
@@ -506,8 +669,6 @@ spec:
               format: int64
               type: integer
           required:
-          - conditions
-          - currentMetrics
           - currentReplicas
           - desiredReplicas
           type: object
@@ -517,3 +678,9 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -678,8 +678,6 @@ spec:
               format: int64
               type: integer
           required:
-          - conditions
-          - currentMetrics
           - currentReplicas
           - desiredReplicas
           type: object

--- a/hack/install-kubebuilder.sh
+++ b/hack/install-kubebuilder.sh
@@ -23,7 +23,7 @@ os=$(go env GOOS)
 arch=$(go env GOARCH)
 
 # download kubebuilder and extract it to tmp
-curl -L https://go.kubebuilder.io/dl/${VERSION}/${os}/${arch} | tar -xz -C $WORK_DIR
+curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${VERSION}/kubebuilder_${VERSION}_${os}_${arch}.tar.gz | tar -xz -C $WORK_DIR
 
 # move to repo_path/bin/kubebuilder - you'll need to set the KUBEBUILDER_ASSETS env var with
 rm -rf "$ROOT/bin/kubebuilder"


### PR DESCRIPTION
### What does this PR do?

* Fix CRD definition to pass the open-api validation
* Update CRD manifest in the helm chart.
* fix kubebuilder download link

### Motivation
When we tried to deploy the current CRD from the main branch with `make deploy` the following was returned by the api server
```
Error: CustomResourceDefinition.apiextensions.k8s.io "watermarkpodautoscalers.datadoghq.com" is invalid: [spec.validation.openAPIV3Schema.properties[spec].properties[metrics].items.x-kubernetes-map-type: Invalid value: "null": must be atomic as item of a list with x-kubernetes-list-type=set, spec.validation.openAPIV3Schema.properties[status].properties[conditions].items.x-kubernetes-map-type: Invalid value: "null": must be atomic as item of a list with x-kubernetes-list-type=set, spec.validation.openAPIV3Schema.properties[status].properties[currentMetrics].items.x-kubernetes-map-type: Invalid value: "null": must be atomic as item of a list with x-kubernetes-list-type=set]
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Try to install the WPA controller with the helm chart in a recent cluster `k8s 1.21` for example.
The install should work.
