### PR TITLE
fix: allow wpa status update even if dry-run:true

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -195,6 +195,9 @@ type WatermarkPodAutoscalerStatus struct {
 	Conditions []autoscalingv2.HorizontalPodAutoscalerCondition `json:"conditions,omitempty"`
 }
 
+// WatermarkPodAutoscalerStatusDryRunCondition ConditionType used when the WPA is in dry run mode
+const WatermarkPodAutoscalerStatusDryRunCondition autoscalingv2.HorizontalPodAutoscalerConditionType = "DryRun"
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WatermarkPodAutoscalerList contains a list of WatermarkPodAutoscaler

--- a/controllers/test/watermarkpodautoscaler_controller_test.go
+++ b/controllers/test/watermarkpodautoscaler_controller_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 // +build !e2e
 
 package controllers
@@ -17,7 +22,6 @@ import (
 )
 
 var _ = Describe("WatermarkPodAutoscaler Controller", func() {
-
 	const (
 		timeout  = time.Second * 30
 		interval = time.Second * 2
@@ -58,6 +62,5 @@ var _ = Describe("WatermarkPodAutoscaler Controller", func() {
 				return true
 			}, timeout, interval).Should(BeTrue())
 		})
-
 	})
 })

--- a/controllers/test/watermarkpodautoscaler_e2e_test.go
+++ b/controllers/test/watermarkpodautoscaler_e2e_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 // +build e2e
 
 package controllers
@@ -5,28 +10,28 @@ package controllers
 import (
 	"context"
 	"fmt"
-	datadoghqv1alpha1 "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
-	wpatest "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1/test"
-	"github.com/DataDog/watermarkpodautoscaler/pkg/util"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	//"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
-	//"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1/test"
-	"github.com/DataDog/watermarkpodautoscaler/test/e2e/metricsserver"
-	"github.com/DataDog/watermarkpodautoscaler/test/e2e/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"time"
+
+	datadoghqv1alpha1 "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
+	wpatest "github.com/DataDog/watermarkpodautoscaler/api/v1alpha1/test"
+	"github.com/DataDog/watermarkpodautoscaler/pkg/util"
+	"github.com/DataDog/watermarkpodautoscaler/test/e2e/metricsserver"
+	"github.com/DataDog/watermarkpodautoscaler/test/e2e/utils"
 )
 
 const (
@@ -65,67 +70,76 @@ func warn(format string, a ...interface{}) {
 }
 
 func ginkgoLog(format string, a ...interface{}) {
-	fmt.Fprintf(GinkgoWriter, format, a...)
+	fmt.Fprintf(GinkgoWriter, format+"\n", a...)
+}
+
+var alreadyExistingObjs = map[dynclient.Object]bool{}
+
+func objectsBeforeEachFunc() {
+	objs, err := metricsserver.InitMetricsServerFiles(GinkgoWriter, "../../test/e2e/metricsserver/deploy", namespace)
+	Expect(err).Should(Succeed())
+	info("We extracted all the files")
+	Expect(err).Should(Succeed())
+	for _, obj := range objs {
+		info("evaluating", obj)
+		if err = createWrapper(ctx, obj); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				alreadyExistingObjs[obj] = true
+				warn(err.Error())
+			}
+			if err = k8sClient.Update(ctx, obj); err != nil {
+				warn(err.Error())
+			}
+		}
+	}
+	Eventually(func() bool {
+		metricsServer := &appsv1.Deployment{}
+		info("checking if deployment here")
+		err = k8sClient.Get(ctx, types.NamespacedName{Name: customMetricsName, Namespace: namespace}, metricsServer)
+		if err != nil {
+			fmt.Fprint(GinkgoWriter, err)
+			return false
+		}
+		info("found the metrics server", metricsServer.Status)
+		return metricsServer.Status.AvailableReplicas != 0
+	}, timeout, interval).Should(BeTrue())
+}
+
+func cleanUpAfter() {
+	for obj := range alreadyExistingObjs {
+		Eventually(func() bool {
+			if err := k8sClient.Delete(ctx, obj); err != nil {
+				if apierrors.IsNotFound(err) {
+					delete(alreadyExistingObjs, obj)
+					return true
+				}
+			}
+			return false
+		}, timeout, interval).Should(BeTrue())
+	}
+}
+
+// Use to keep track of created resources
+func createWrapper(ctx context.Context, obj dynclient.Object, opts ...dynclient.CreateOption) error {
+	if err := k8sClient.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+	alreadyExistingObjs[obj] = true
+	return nil
 }
 
 var _ = Describe("WatermarkPodAutoscaler Controller", func() {
 	namespace := testConfig.namespace
 	ctx := context.Background()
-	alreadyExistingObjs := make(map[dynclient.Object]bool)
-	BeforeEach(func() {
-		objs, err := metricsserver.InitMetricsServerFiles(GinkgoWriter, "../../test/e2e/metricsserver/deploy", namespace)
-		Expect(err).Should(Succeed())
-		info("We extracted all the files")
-		Expect(err).Should(Succeed())
-		for _, obj := range objs {
-			info("evaluating", obj)
-			if err = k8sClient.Create(ctx, obj); err != nil {
-				if !apierrors.IsAlreadyExists(err) {
-					alreadyExistingObjs[obj] = true
-					warn(err.Error())
-				}
-				if err = k8sClient.Update(ctx, obj); err != nil {
-					warn(err.Error())
-				}
-			}
-		}
-		Eventually(func() bool {
-			metricsServer := &appsv1.Deployment{}
-			info("checking if deployment here")
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: customMetricsName, Namespace: namespace}, metricsServer)
-			if err != nil {
-				fmt.Fprint(GinkgoWriter, err)
-				return false
-			}
-			info("found the metrics server", metricsServer.Status)
-			return metricsServer.Status.AvailableReplicas != 0
-		}, timeout, interval).Should(BeTrue())
-	})
 
-	AfterEach(func() {
-		objs, err := metricsserver.InitMetricsServerFiles(GinkgoWriter, "../../test/e2e/metricsserver/deploy", namespace)
-		Expect(err).Should(Succeed())
-		for _, obj := range objs {
-			info("deleting", obj)
-			if ok := alreadyExistingObjs[obj]; ok {
-				info("obj already existed, not deleting", obj)
-				continue
-			}
-			if err = k8sClient.Delete(ctx, obj); err != nil {
-				if !apierrors.IsAlreadyExists(err) {
-					warn(err.Error())
-				}
-				if err = k8sClient.Update(ctx, obj); err != nil {
-					warn(err.Error())
-				}
-			}
-		}
-	})
 	Context("Main test", func() {
+		JustBeforeEach(func() { objectsBeforeEachFunc() })
+		JustAfterEach(func() { cleanUpAfter() })
+
 		It("Should scale deployment with metric out of bounds", func() {
 			// create Fake App Deployment
 			fakeAppDep := utils.NewFakeAppDeployment(namespace, "fakeapp", nil)
-			Expect(k8sClient.Create(ctx, fakeAppDep)).Should(Succeed())
+			Expect(createWrapper(ctx, fakeAppDep)).Should(Succeed())
 			newWPAOptions := &wpatest.NewWatermarkPodAutoscalerOptions{
 				Spec: &datadoghqv1alpha1.WatermarkPodAutoscalerSpec{
 					ScaleTargetRef: datadoghqv1alpha1.CrossVersionObjectReference{
@@ -147,14 +161,14 @@ var _ = Describe("WatermarkPodAutoscaler Controller", func() {
 					},
 				},
 			}
-			name := "app"
-			newWPA := wpatest.NewWatermarkPodAutoscaler(namespace, name, newWPAOptions)
+
+			newWPAName := "wpa-fakeapp"
+			newWPA := wpatest.NewWatermarkPodAutoscaler(namespace, newWPAName, newWPAOptions)
 			key := types.NamespacedName{
 				Namespace: namespace,
-				Name:      name,
+				Name:      newWPAName,
 			}
-			Expect(k8sClient.Create(ctx, newWPA)).Should(Succeed())
-
+			Expect(createWrapper(ctx, newWPA)).Should(Succeed())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, key, newWPA)
 				if err != nil {
@@ -185,7 +199,7 @@ var _ = Describe("WatermarkPodAutoscaler Controller", func() {
 			}
 			metricConfigMap.Name = configMapName
 			metricConfigMap.Namespace = namespace
-			Expect(k8sClient.Create(ctx, metricConfigMap)).Should(Succeed())
+			Expect(createWrapper(ctx, metricConfigMap)).Should(Succeed())
 			info("metricConfigMap created: %s/%s", namespace, configMapName)
 
 			Eventually(func() bool {
@@ -235,34 +249,78 @@ var _ = Describe("WatermarkPodAutoscaler Controller", func() {
 				}
 				return false
 			}, timeout, interval).Should(BeTrue())
-
 		})
+	})
 
-		//It("Should handle WPA", func() {
-		//	podList := corev1.PodList{}
-		//	Eventually(func() bool {
-		//		err = k8sClient.List(ctx, podList)
-		//		if err != nil {
-		//			fmt.Fprint(GinkgoWriter, err)
-		//			return false
-		//		}
-		//		return true
-		//	}, timeout, interval).Should(BeTrue())
-		//
-		//	wpaOptions := &test.NewWatermarkPodAutoscalerOptions{
-		//		Spec: &v1alpha1.WatermarkPodAutoscalerSpec{},
-		//	}
-		//	wpa := test.NewWatermarkPodAutoscaler(namespace, name, wpaOptions)
-		//	Expect(k8sClient.Create(ctx, wpa)).Should(Succeed())
-		//	Eventually(func() bool {
-		//		err = k8sClient.Get(ctx, key, wpa)
-		//		if err != nil {
-		//			fmt.Fprint(GinkgoWriter, err)
-		//			return false
-		//		}
-		//		return true
-		//	}, timeout, interval).Should(BeTrue())
-		//})
+	Context("Dry run test", func() {
+		It("Should propose scale down, but do nothing", func() {
+			// create Fake App Deployment
+			fakeDeploymentOptions := &utils.NewFakeAppDeploymentOptions{
+				Replicas: 5,
+			}
+			appName := "dryrunapp"
+			fakeAppDep := utils.NewFakeAppDeployment(namespace, appName, fakeDeploymentOptions)
+			Expect(createWrapper(ctx, fakeAppDep)).Should(Succeed())
 
+			newWPAOptions := &wpatest.NewWatermarkPodAutoscalerOptions{
+				Spec: &datadoghqv1alpha1.WatermarkPodAutoscalerSpec{
+					ScaleTargetRef: datadoghqv1alpha1.CrossVersionObjectReference{
+						Name:       fakeAppDep.Name,
+						Kind:       "Deployment",
+						APIVersion: "apps/v1",
+					},
+					MaxReplicas: 3,
+					DryRun:      true,
+					Metrics: []datadoghqv1alpha1.MetricSpec{
+						{
+							Type: datadoghqv1alpha1.ExternalMetricSourceType,
+							External: &datadoghqv1alpha1.ExternalMetricSource{
+								MetricName:     "metric_name",
+								MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value"}},
+								HighWatermark:  resource.NewQuantity(100, resource.DecimalSI),
+								LowWatermark:   resource.NewQuantity(50, resource.DecimalSI),
+							},
+						},
+					},
+				},
+			}
+			newWPA := wpatest.NewWatermarkPodAutoscaler(namespace, appName, newWPAOptions)
+			key := types.NamespacedName{
+				Namespace: namespace,
+				Name:      appName,
+			}
+			Expect(createWrapper(ctx, newWPA)).Should(Succeed())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, key, newWPA)
+				if err != nil {
+					fmt.Fprint(GinkgoWriter, err)
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+			warn("WPA kind is", newWPA)
+
+			// check that DryRun condition is present
+			// it also validate that the controller is able to create the status even in dryRun mode.
+			Eventually(func() bool {
+				wpa := &datadoghqv1alpha1.WatermarkPodAutoscaler{}
+				objKey := dynclient.ObjectKey{
+					Namespace: namespace,
+					Name:      newWPA.Name,
+				}
+
+				if err := k8sClient.Get(ctx, objKey, wpa); err != nil {
+					fmt.Fprint(GinkgoWriter, err)
+					return false
+				}
+				for _, condition := range wpa.Status.Conditions {
+					if condition.Type == datadoghqv1alpha1.WatermarkPodAutoscalerStatusDryRunCondition && condition.Status == corev1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+		})
 	})
 })

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -1278,15 +1278,15 @@ func TestSetCondition(t *testing.T) {
 					LastTransitionTime: metav1.Time{Time: time.Now().Add(-1 * time.Minute)},
 				},
 				{
-					Type:               dryRunCondition,
+					Type:               v1alpha1.WatermarkPodAutoscalerStatusDryRunCondition,
 					Status:             corev1.ConditionFalse,
 					LastTransitionTime: metav1.Time{Time: time.Now().Add(-2 * time.Minute)},
 				},
 			},
-			newConditionType: dryRunCondition,
+			newConditionType: v1alpha1.WatermarkPodAutoscalerStatusDryRunCondition,
 			// The LastTransitionTime of dryRun should be the most recent one
 			// now. That's why it should appear first in the resulting array.
-			expectedOrder: []v2beta1.HorizontalPodAutoscalerConditionType{dryRunCondition, v2beta1.ScalingLimited},
+			expectedOrder: []v2beta1.HorizontalPodAutoscalerConditionType{v1alpha1.WatermarkPodAutoscalerStatusDryRunCondition, v2beta1.ScalingLimited},
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

* This PR remove the initialisation of `metricStatuses` to an empty
slice. like this the status should be created.

* Fix end2end test to cleanup properly resources, to allow the deletion of the test namespace.

### Motivation

In specific configuration if the status is empty (new WPA) in dry
run mode, and if `currentReplica` > max or < min, the status is not
created properly because wpa.status.CurrentMetrics is a empty slice
but not a nil slice.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Possible test scenario:
* create a deployement with a replicas value = 5
* create wpa targeting the deployment with a maxValue = 3 and dryRun mode
  enabled.

Results:
* The WPA status should be created.
* No logs like like: `is invalid: status.currentMetrics: Required value`.
