### PR TITLE
Prevent downscale when value over HWM if some pods are unready

### DIFF
--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -193,6 +193,10 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 		}
 		// tolerance: milliValue/10 to represent the %.
 		logger.Info("Value is above highMark", "usage", utilizationQuantity.String(), "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "tolerance (%)", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedHM", adjustedHM, "adjustedUsage", adjustedUsage)
+		if replicaCount < currentReplicas {
+			logger.Info("Recommendation is lower than current number of replicas while attempting to upscale, aborting", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas)
+			replicaCount = currentReplicas
+		}
 	case adjustedUsage < adjustedLM:
 		replicaCount = int32(math.Floor(float64(currentReadyReplicas) * adjustedUsage / (float64(lowMark.MilliValue()))))
 		// Keep a minimum of 1 replica

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -913,7 +913,7 @@ func TestReplicaCalcAverageScaleUpPendingNoScaleStretchTolerance(t *testing.T) {
 	}
 
 	tc := replicaCalcTestCase{
-		expectedReplicas: 2,
+		expectedReplicas: 3,
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
@@ -1345,7 +1345,7 @@ func TestPendingNotExpiredScale(t *testing.T) {
 	tc.runTest(t)
 }
 
-// We have pods that are expired and only one is above the HWM so we end up downscaling.
+// We have pods that are expired and only one is above the HWM so we keep the number of replicas.
 func TestPendingExpiredHigherWatermarkDownscale(t *testing.T) {
 	logf.SetLogger(zap.New())
 
@@ -1362,7 +1362,7 @@ func TestPendingExpiredHigherWatermarkDownscale(t *testing.T) {
 	startTime := metav1.Unix(now.Unix()-120, 0)
 	expired := metav1.Unix(now.Unix()-2*readinessDelay, 0)
 	tc := replicaCalcTestCase{
-		expectedReplicas: 2,
+		expectedReplicas: 3,
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{


### PR DESCRIPTION
### What does this PR do?

With the current logic, if the metric is above the high watermark but you have some unready replicas, you can end up with fewer replicas than originally.
This is a problem for applications that take time to be ready for instance as it allows effectively downscaling when the scenario ought to yield a scale up event.

The expectation here is that even if some pods never become ready, we will keep at least as many pods as the status of the target has and this until the recommendation becomes higher than the current number of ready replicas.
 
I also fixed some tests that reflected this (incorrect, but designed) behavior. 
### Motivation

Better support for edge cases

### Additional Notes

if you have 5 ready replicas out of 10 in the spec of your deployment, 5 is used to compute the recommendation (based on the ratio of value/High Watermark). If the ratio is <2, this would trigger a scaling event to a value under 10. This is obviously undesired as it at best removes unready replicas but at worse remove ready ones.

### Describe your test plan

Create a deployment with a few unready replicas (could work with taints) and configure the WPA to trigger a scale up event, make sure you do not end up with fewer replicas than originally and see the log:
```
"Recommendation is lower than current number of replicas while attempting to upscale, aborting", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas
```


