### PR TITLE
Expose option to specify number of workers

### DIFF
--- a/controllers/test/suite_test.go
+++ b/controllers/test/suite_test.go
@@ -112,7 +112,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = (&controllers.WatermarkPodAutoscalerReconciler{
 		Client: k8sManager.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("WatermarkPodAutoscaler"),
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, 1)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -39,6 +39,7 @@ import (
 	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/external_metrics"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -701,9 +702,10 @@ func updatePredicate(ev event.UpdateEvent) bool {
 }
 
 // SetupWithManager creates a new Watermarkpodautoscaler controller
-func (r *WatermarkPodAutoscalerReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *WatermarkPodAutoscalerReconciler) SetupWithManager(mgr ctrl.Manager, workers int) error {
 	b := ctrl.NewControllerManagedBy(mgr).
-		For(&datadoghqv1alpha1.WatermarkPodAutoscaler{}, builder.WithPredicates(predicate.Funcs{UpdateFunc: updatePredicate}))
+		For(&datadoghqv1alpha1.WatermarkPodAutoscaler{}, builder.WithPredicates(predicate.Funcs{UpdateFunc: updatePredicate})).
+		WithOptions(controller.Options{MaxConcurrentReconciles: workers})
 	err := b.Complete(r)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	var syncPeriodSeconds int
 	var leaderElectionResourceLock string
 	var ddProfilingEnabled bool
+	var workers int
 	flag.BoolVar(&printVersionArg, "version", false, "print version and exit")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", true,
@@ -65,6 +66,8 @@ func main() {
 	flag.IntVar(&syncPeriodSeconds, "syncPeriodSeconds", 60*60, "The informers resync period in seconds") // default 1 hour
 	flag.StringVar(&leaderElectionResourceLock, "leader-election-resource", "configmaps", "determines which resource lock to use for leader election. option:[configmapsleases|endpointsleases|configmaps]")
 	flag.BoolVar(&ddProfilingEnabled, "ddProfilingEnabled", false, "Enable the datadog profiler")
+	flag.IntVar(&workers, "workers", 1, "Maximum number of concurrent Reconciles which can be run")
+
 	logLevel := zap.LevelFlag("loglevel", zapcore.InfoLevel, "Set log level")
 
 	flag.Parse()
@@ -120,7 +123,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Log:    managerLogger,
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, workers); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WatermarkPodAutoscaler")
 		exitCode = 1
 		return


### PR DESCRIPTION
### What does this PR do?

Will allow to create threads to consume from the workerqueue.

### Motivation

With a high number of objects, it allows faster reconciliation loop by using more goroutines.
This is a native controller runtime feature.

### Describe your test plan

Verify that with a high number of WPAs to process the queue depth and duration decreases (with ~50 WPAs going from 1 to 4 workers)

<img width="1055" alt="Screen Shot 2021-12-20 at 5 28 53 PM" src="https://user-images.githubusercontent.com/7433560/146841149-d2114ae7-7bb0-405d-b7a5-0b68aa2f56d4.png">

