### PR TITLE
Introduce option to specify minimum ratio of available pods

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -93,6 +93,9 @@ type WatermarkPodAutoscalerSpec struct {
 	Metrics []MetricSpec `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty"`
+	// MinAvailableReplicaPerc indicates the minimum percentage of replicas that need to be available in order for the
+	// controller to autoscale the target.
+	MinAvailableReplicaPerc int32 `json:"minAvailableReplicaPerc,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	MaxReplicas int32 `json:"maxReplicas,omitempty"`
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -93,9 +93,10 @@ type WatermarkPodAutoscalerSpec struct {
 	Metrics []MetricSpec `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty"`
-	// MinAvailableReplicaPerc indicates the minimum percentage of replicas that need to be available in order for the
+	// MinAvailableReplicaPercentage indicates the minimum percentage of replicas that need to be available in order for the
 	// controller to autoscale the target.
-	MinAvailableReplicaPerc int32 `json:"minAvailableReplicaPerc,omitempty"`
+	// +kubebuilder:validation:Maximum=100
+	MinAvailableReplicaPercentage int32 `json:"minAvailableReplicaPercentage,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	MaxReplicas int32 `json:"maxReplicas,omitempty"`
 	// +kubebuilder:validation:Minimum=1

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -320,6 +320,13 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 							Format: "int32",
 						},
 					},
+					"minAvailableReplicaPerc": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MinAvailableReplicaPerc indicates the minimum percentage of replicas that need to be available in order for the controller to autoscale the target.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"maxReplicas": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -320,9 +320,9 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 							Format: "int32",
 						},
 					},
-					"minAvailableReplicaPerc": {
+					"minAvailableReplicaPercentage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MinAvailableReplicaPerc indicates the minimum percentage of replicas that need to be available in order for the controller to autoscale the target.",
+							Description: "MinAvailableReplicaPercentage indicates the minimum percentage of replicas that need to be available in order for the controller to autoscale the target.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -311,7 +311,6 @@ spec:
               minimum: 1
               type: integer
           required:
-          - minAvailableReplicaPerc
           - scaleTargetRef
           type: object
         status:

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -239,6 +239,12 @@ spec:
                 - type
                 type: object
               type: array
+            minAvailableReplicaPerc:
+              description: MinAvailableReplicaPerc indicates the minimum percentage
+                of replicas that need to be available in order for the controller
+                to autoscale the target.
+              format: int32
+              type: integer
             minReplicas:
               format: int32
               minimum: 1
@@ -305,6 +311,7 @@ spec:
               minimum: 1
               type: integer
           required:
+          - minAvailableReplicaPerc
           - scaleTargetRef
           type: object
         status:

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -239,11 +239,12 @@ spec:
                 - type
                 type: object
               type: array
-            minAvailableReplicaPerc:
-              description: MinAvailableReplicaPerc indicates the minimum percentage
+            minAvailableReplicaPercentage:
+              description: MinAvailableReplicaPercentage indicates the minimum percentage
                 of replicas that need to be available in order for the controller
                 to autoscale the target.
               format: int32
+              maximum: 100
               type: integer
             minReplicas:
               format: int32

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -62,10 +62,24 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, target
 	if err != nil {
 		logger.Error(err, "Could not parse the labels of the target")
 	}
-	currentReadyReplicas, err := c.getReadyPodsCount(logger, target, lbl, time.Duration(wpa.Spec.ReadinessDelaySeconds)*time.Second)
+	podList, err := c.podLister.Pods(target.Namespace).List(lbl)
+	if err != nil {
+		return ReplicaCalculation{}, fmt.Errorf("unable to get pods while calculating replica count: %v", err)
+	}
+	if len(podList) == 0 {
+		return ReplicaCalculation{}, fmt.Errorf("no pods returned by selector while calculating replica count")
+	}
+
+	currentReadyReplicas, incorrectTargetPodsCount, err := c.getReadyPodsCount(logger, target.Name, podList, time.Duration(wpa.Spec.ReadinessDelaySeconds)*time.Second)
 	if err != nil {
 		return ReplicaCalculation{}, fmt.Errorf("unable to get the number of ready pods across all namespaces for %v: %s", lbl, err.Error())
 	}
+
+	ratioReadyPods := (100 * currentReadyReplicas / (int32(len(podList)) - incorrectTargetPodsCount))
+	if ratioReadyPods < wpa.Spec.MinAvailableReplicaPerc {
+		return ReplicaCalculation{}, fmt.Errorf("%d %% of the pods are unready, will not autoscale %s/%s", ratioReadyPods, target.Namespace, target.Name)
+	}
+
 	averaged := 1.0
 	if wpa.Spec.Algorithm == "average" {
 		averaged = float64(currentReadyReplicas)
@@ -156,6 +170,12 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 	readyPods, ignoredPods := groupPods(logger, podList, target.Name, metrics, resourceName, readiness)
 	readyPodCount := len(readyPods)
 
+	ratioReadyPods := int32(100 * readyPodCount / (len(podList) - len(ignoredPods)))
+
+	if ratioReadyPods < wpa.Spec.MinAvailableReplicaPerc {
+		return ReplicaCalculation{}, fmt.Errorf("%d %% of the pods are unready, will not autoscale %s/%s", ratioReadyPods, target.Namespace, target.Name)
+	}
+
 	removeMetricsForPods(metrics, ignoredPods)
 	if len(metrics) == 0 {
 		return ReplicaCalculation{0, 0, time.Time{}}, fmt.Errorf("did not receive metrics for any ready pods")
@@ -220,20 +240,12 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 	return replicaCount, utilizationQuantity.MilliValue()
 }
 
-func (c *ReplicaCalculator) getReadyPodsCount(log logr.Logger, target *autoscalingv1.Scale, selector labels.Selector, readinessDelay time.Duration) (int32, error) {
-	podList, err := c.podLister.Pods(target.Namespace).List(selector)
-	if err != nil {
-		return 0, fmt.Errorf("unable to get pods while calculating replica count: %v", err)
-	}
-	if len(podList) == 0 {
-		return 0, fmt.Errorf("no pods returned by selector while calculating replica count")
-	}
-
+func (c *ReplicaCalculator) getReadyPodsCount(log logr.Logger, targetName string, podList []*corev1.Pod, readinessDelay time.Duration) (int32, int32, error) {
 	toleratedAsReadyPodCount := 0
 	var incorrectTargetPodsCount int
 	for _, pod := range podList {
 		// matchLabel might be too broad, use the OwnerRef to scope over the actual target
-		if ok := checkOwnerRef(pod.OwnerReferences, target.Name); !ok {
+		if ok := checkOwnerRef(pod.OwnerReferences, targetName); !ok {
 			incorrectTargetPodsCount++
 			continue
 		}
@@ -253,10 +265,12 @@ func (c *ReplicaCalculator) getReadyPodsCount(log logr.Logger, target *autoscali
 	}
 	log.Info("getReadyPodsCount", "full podList length", len(podList), "toleratedAsReadyPodCount", toleratedAsReadyPodCount, "incorrectly targeted pods", incorrectTargetPodsCount)
 	if toleratedAsReadyPodCount == 0 {
-		return 0, fmt.Errorf("among the %d pods, none is ready. Skipping recommendation", len(podList))
+		return 0, int32(incorrectTargetPodsCount), fmt.Errorf("among the %d pods, none is ready. Skipping recommendation", len(podList))
 	}
-	return int32(toleratedAsReadyPodCount), nil
+
+	return int32(toleratedAsReadyPodCount), int32(incorrectTargetPodsCount), nil
 }
+
 func checkOwnerRef(ownerRef []metav1.OwnerReference, targetName string) bool {
 	for _, o := range ownerRef {
 		if o.Kind != "ReplicaSet" && o.Kind != "StatefulSet" {

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -76,7 +76,7 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, target
 	}
 
 	ratioReadyPods := (100 * currentReadyReplicas / (int32(len(podList)) - incorrectTargetPodsCount))
-	if ratioReadyPods < wpa.Spec.MinAvailableReplicaPerc {
+	if ratioReadyPods < wpa.Spec.MinAvailableReplicaPercentage {
 		return ReplicaCalculation{}, fmt.Errorf("%d %% of the pods are unready, will not autoscale %s/%s", ratioReadyPods, target.Namespace, target.Name)
 	}
 
@@ -172,7 +172,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 
 	ratioReadyPods := int32(100 * readyPodCount / (len(podList) - len(ignoredPods)))
 
-	if ratioReadyPods < wpa.Spec.MinAvailableReplicaPerc {
+	if ratioReadyPods < wpa.Spec.MinAvailableReplicaPercentage {
 		return ReplicaCalculation{}, fmt.Errorf("%d %% of the pods are unready, will not autoscale %s/%s", ratioReadyPods, target.Namespace, target.Name)
 	}
 

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -1338,11 +1338,11 @@ func TestTooManyUnreadyPods(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
-				Algorithm:                    "average",
-				MinAvailableReplicaPerc:      30,
-				Tolerance:                    *resource.NewMilliQuantity(20, resource.DecimalSI),
-				Metrics:                      []v1alpha1.MetricSpec{metric1},
-				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
+				Algorithm:                     "average",
+				MinAvailableReplicaPercentage: 30,
+				Tolerance:                     *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                       []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo:  v1alpha1.NewInt32(1),
 			},
 		},
 		podPhase:      []corev1.PodPhase{corev1.PodPending, corev1.PodPending, corev1.PodPending, corev1.PodRunning},

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -449,8 +449,8 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasForMetrics(logger logr
 				if errMetricsServer != nil {
 					replicaProposal.Delete(promLabelsForWpaWithMetricName)
 					r.eventRecorder.Event(wpa, corev1.EventTypeWarning, datadoghqv1alpha1.ConditionReasonFailedGetExternalMetrics, errMetricsServer.Error())
-					setCondition(wpa, autoscalingv2.ScalingActive, corev1.ConditionFalse, datadoghqv1alpha1.ConditionReasonFailedGetExternalMetrics, "the HPA was unable to compute the replica count: %v", errMetricsServer)
-					return 0, "", nil, time.Time{}, fmt.Errorf("failed to get external metric %s: %v", metricSpec.External.MetricName, errMetricsServer)
+					setCondition(wpa, autoscalingv2.ScalingActive, corev1.ConditionFalse, datadoghqv1alpha1.ConditionReasonFailedGetExternalMetrics, "the WPA was unable to compute the replica count: %v", errMetricsServer)
+					return 0, "", nil, time.Time{}, fmt.Errorf("failed to compute replicas based on external metric %s: %v", metricSpec.External.MetricName, errMetricsServer)
 				}
 				replicaCountProposal = replicaCalculation.replicaCount
 				utilizationProposal = replicaCalculation.utilization

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -699,7 +699,7 @@ func TestReconcileWatermarkPodAutoscaler_computeReplicasForMetrics(t *testing.T)
 				// With 8 replicas, the avg algo and an external value returned of 100 we have 10 replicas and the utilization of 10
 				return ReplicaCalculation{0, 0, time.Time{}}, fmt.Errorf("unable to fetch metrics from external metrics API")
 			},
-			err: fmt.Errorf("failed to get external metric deadbeef: unable to fetch metrics from external metrics API"),
+			err: fmt.Errorf("failed to compute replicas based on external metric deadbeef: unable to fetch metrics from external metrics API"),
 		},
 		{
 			name: "Multiple metrics Case",


### PR DESCRIPTION
### What does this PR do?

Adds an option to specify the minimum percentage of pods from a target that need to be available in order for the controller to scale a target.
Note that the amount of ready replicas does not take into account replicas that are not properly labled (e.g. we only consider the replicas from the target in the WPA spec). We also consider replicas in pending during `ReadinessDelaySeconds` s.

### Motivation

Better control of edge cases. Works as a fast fail.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Scale rapidly a deployment that takes a long time to be marked available (use the probes) with a high ReadinessDelaySeconds to make sure that the controller stops if there are too many pending replicas.