### PR TITLE
Fix wpa plugin

### DIFF
--- a/cmd/kubectl-wpa/app/dryrun/dryrun.go
+++ b/cmd/kubectl-wpa/app/dryrun/dryrun.go
@@ -27,6 +27,11 @@ var dryrunExample = `
 	kubectl wpa %[1]s foo
 `
 
+var dryrunRevertExample = `
+	# %[1]s reverts to a state specified in a file
+	kubectl %[1]s -f saved_state.csv
+`
+
 // dryrunOptions provides information required to manage WatermarkPodAutoscaler.
 type dryrunOptions struct {
 	configFlags *genericclioptions.ConfigFlags
@@ -186,9 +191,12 @@ func newCmdRevert(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "revert",
 		Short:        "revert all WPA instance dry-run configuration from a csv backup file",
-		Example:      fmt.Sprintf(dryrunExample, "dry-run disable"),
+		Example:      fmt.Sprintf(dryrunRevertExample, "dry-run revert"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
+			if o.csvFile == "" {
+				return fmt.Errorf("the revert command requires a file as input")
+			}
 			if err := o.complete(c, args); err != nil {
 				return err
 			}

--- a/cmd/kubectl-wpa/app/dryrun/dryrun.go
+++ b/cmd/kubectl-wpa/app/dryrun/dryrun.go
@@ -70,16 +70,6 @@ func NewCmdDryRun(streams genericclioptions.IOStreams) *cobra.Command {
 		Use:          "dry-run",
 		Short:        "configure WPA(s) dry-run",
 		SilenceUsage: true,
-		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.complete(c, args); err != nil {
-				return err
-			}
-			if err := o.validate(); err != nil {
-				return err
-			}
-
-			return nil
-		},
 	}
 
 	cmd.AddCommand(newCmdDryRunEnabled(streams))
@@ -189,13 +179,13 @@ func newCmdRevert(streams genericclioptions.IOStreams) *cobra.Command {
 	o.enabledDryRun = false
 
 	cmd := &cobra.Command{
-		Use:          "revert",
+		Use:          "revert -f [saved_state_csv_file]",
 		Short:        "revert all WPA instance dry-run configuration from a csv backup file",
 		Example:      fmt.Sprintf(dryrunRevertExample, "dry-run revert"),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
 			if o.csvFile == "" {
-				return fmt.Errorf("the revert command requires a file as input")
+				return fmt.Errorf("the revert command requires a file as input use `--help` for an example")
 			}
 			if err := o.complete(c, args); err != nil {
 				return err

--- a/cmd/kubectl-wpa/app/dryrun/dryrun.go
+++ b/cmd/kubectl-wpa/app/dryrun/dryrun.go
@@ -29,7 +29,8 @@ var dryrunExample = `
 
 var dryrunRevertExample = `
 	# %[1]s reverts to a state specified in a file
-	kubectl %[1]s -f saved_state.csv
+	kubectl wpa dry-run list --all -ocsv > saved_state.csv
+	kubectl wpa %[1]s -f saved_state.csv
 `
 
 // dryrunOptions provides information required to manage WatermarkPodAutoscaler.
@@ -396,9 +397,10 @@ func dryRunBool(input string) bool {
 		return false
 	case enabledString:
 		return true
+	default:
+		fmt.Printf("Warning: Incorrect value for dry-run: %s, defaulting to true \n", input)
+		return true
 	}
-
-	return false
 }
 
 const (


### PR DESCRIPTION
### What does this PR do?

Improve UX of the new WPA plugin.
1/ Fix the revert help example and add a more explicit usage.
2/ revert with no/wrong input would hang as it required a file but there was no check.
3/ `kubectl wpa dry-run` should be used in conjunction with a subcommand. Return the help if it's missing a subcommand
4/ if the saved stated csv is malformed do not default to false and also print a warning.

### Motivation

part of the WPA 0.4.0 QA.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
