### PR TITLE
fix: dryrun status not up-to-date

### DIFF
--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -179,6 +179,18 @@ var (
 			resourceNamePromLabel,
 			resourceKindPromLabel,
 		})
+	dryRun = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Subsystem: subsystem,
+			Name:      "dry_run",
+			Help:      "Gauge reflecting the WPA dry-run status",
+		},
+		[]string{
+			wpaNamePromLabel,
+			resourceNamespacePromLabel,
+			resourceNamePromLabel,
+			resourceKindPromLabel,
+		})
 	labelsInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: subsystem,
@@ -201,6 +213,7 @@ func init() {
 	sigmetrics.Registry.MustRegister(transitionCountdown)
 	sigmetrics.Registry.MustRegister(replicaMin)
 	sigmetrics.Registry.MustRegister(replicaMax)
+	sigmetrics.Registry.MustRegister(dryRun)
 	sigmetrics.Registry.MustRegister(labelsInfo)
 }
 
@@ -235,6 +248,7 @@ func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onl
 			promLabelsInfo[eLabel] = eLabelValue
 		}
 		labelsInfo.Delete(promLabelsInfo)
+		dryRun.Delete(promLabelsForWpa)
 	}
 
 	for _, metricSpec := range wpa.Spec.Metrics {

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -125,6 +125,8 @@ func (r *WatermarkPodAutoscalerReconciler) Reconcile(ctx context.Context, reques
 		return reconcile.Result{}, err
 	}
 
+	wpaStatusOriginal := instance.Status.DeepCopy()
+
 	if !datadoghqv1alpha1.IsDefaultWatermarkPodAutoscaler(instance) {
 		log.Info("Some configuration options are missing, falling back to the default ones")
 		defaultWPA := datadoghqv1alpha1.DefaultWatermarkPodAutoscaler(instance)
@@ -140,7 +142,6 @@ func (r *WatermarkPodAutoscalerReconciler) Reconcile(ctx context.Context, reques
 		// If the WPA spec is incorrect (most likely, in "metrics" section) stop processing it
 		// When the spec is updated, the wpa will be re-added to the reconcile queue
 		r.eventRecorder.Event(instance, corev1.EventTypeWarning, datadoghqv1alpha1.ReasonFailedSpecCheck, err.Error())
-		wpaStatusOriginal := instance.Status.DeepCopy()
 		setCondition(instance, autoscalingv2.AbleToScale, corev1.ConditionFalse, datadoghqv1alpha1.ReasonFailedSpecCheck, "Invalid WPA specification: %s", err)
 		if err = r.updateStatusIfNeeded(ctx, wpaStatusOriginal, instance); err != nil {
 			r.eventRecorder.Event(instance, corev1.EventTypeWarning, datadoghqv1alpha1.ReasonFailedUpdateStatus, err.Error())
@@ -153,12 +154,16 @@ func (r *WatermarkPodAutoscalerReconciler) Reconcile(ctx context.Context, reques
 
 	fillMissingWatermark(log, instance)
 
-	if err := r.reconcileWPA(ctx, log, instance); err != nil {
+	if err := r.reconcileWPA(ctx, log, wpaStatusOriginal, instance); err != nil {
 		log.Info("Error during reconcileWPA", "error", err)
 		r.eventRecorder.Event(instance, corev1.EventTypeWarning, datadoghqv1alpha1.ReasonFailedProcessWPA, err.Error())
 		setCondition(instance, autoscalingv2.AbleToScale, corev1.ConditionFalse, datadoghqv1alpha1.ReasonFailedProcessWPA, "Error happened while processing the WPA")
 		// In case of `reconcileWPA` error, we need to requeue the Resource in order to retry to process it again
 		// we put a delay in order to not retry directly and limit the number of retries if it only a transient issue.
+		if err2 := r.updateStatusIfNeeded(ctx, wpaStatusOriginal, instance); err2 != nil {
+			r.eventRecorder.Event(instance, corev1.EventTypeWarning, datadoghqv1alpha1.ReasonFailedUpdateStatus, err2.Error())
+			return reconcile.Result{}, err2
+		}
 		return reconcile.Result{RequeueAfter: requeueAfterForWPAErrors(err)}, nil
 	}
 
@@ -166,7 +171,7 @@ func (r *WatermarkPodAutoscalerReconciler) Reconcile(ctx context.Context, reques
 }
 
 // reconcileWPA is the core of the controller.
-func (r *WatermarkPodAutoscalerReconciler) reconcileWPA(ctx context.Context, logger logr.Logger, wpa *datadoghqv1alpha1.WatermarkPodAutoscaler) error {
+func (r *WatermarkPodAutoscalerReconciler) reconcileWPA(ctx context.Context, logger logr.Logger, wpaStatusOriginal *datadoghqv1alpha1.WatermarkPodAutoscalerStatus, wpa *datadoghqv1alpha1.WatermarkPodAutoscaler) error {
 	defer func() {
 		if err1 := recover(); err1 != nil {
 			logger.Error(fmt.Errorf("recover error"), "RunTime error in reconcileWPA", "returnValue", err1)
@@ -194,7 +199,6 @@ func (r *WatermarkPodAutoscalerReconciler) reconcileWPA(ctx context.Context, log
 	}
 	currentReplicas := currentScale.Status.Replicas
 	logger.Info("Target deploy", "replicas", currentReplicas)
-	wpaStatusOriginal := wpa.Status.DeepCopy()
 
 	dryRunMetricValue := 0
 	if wpa.Spec.DryRun {

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -589,7 +589,8 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 			if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: tt.args.wpa.Name, Namespace: tt.args.wpa.Namespace}, wpa); err != nil {
 				t.Errorf("unable to get wpa, err: %v", err)
 			}
-			err := r.reconcileWPA(context.TODO(), logf.Log.WithName(tt.name), wpa)
+			originalWPAStatus := wpa.Status.DeepCopy()
+			err := r.reconcileWPA(context.TODO(), logf.Log.WithName(tt.name), originalWPAStatus, wpa)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileWatermarkPodAutoscaler.Reconcile() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
 	"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1/test"
-
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -539,7 +538,7 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 				if wpa.Status.DesiredReplicas != desired {
 					return fmt.Errorf(fmt.Sprintf("incorrect amount of desired replicas. Expected %d - has %d", desired, wpa.Status.DesiredReplicas))
 				}
-				if len(wpa.Status.Conditions) != 3 {
+				if len(wpa.Status.Conditions) != 4 {
 					return fmt.Errorf("incomplete reconciliation process, missing conditions")
 				}
 				for _, c := range wpa.Status.Conditions {


### PR DESCRIPTION
### What does this PR do?

Fix the `dryRun` status condition update.

the controller was setting the `dryRun` condition to early in the reconcile function.
At that time the `originalStatus` wasn't created (deepCopy). So when the function 
`updateStatusIfNeeded()` was comparing the `wpa.Status` with the  `originalStatus`
it didn't seen any different, so no WPA.status update was triggered.
Only if another element in the `status` was modify at the same time, was triggering
and update of the `dryRun` status condition.

### Motivation

Improve WPA UX, by returning valid information in the WPA status.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

create a dummy deployment like: 
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
    spec:
      containers:
      - name: redis
        image: redis
        ports:
        - name: redis
          containerPort: 6379
```

create the following wpa
```yaml
apiVersion: datadoghq.com/v1alpha1
kind: WatermarkPodAutoscaler
metadata:
  name: example1-watermarkpodautoscaler
  labels:
    app: example
spec:
  downscaleForbiddenWindowSeconds: 60
  upscaleForbiddenWindowSeconds: 30
  scaleDownLimitFactor: 30
  scaleUpLimitFactor: 50
  minReplicas: 4
  maxReplicas: 9
  scaleTargetRef:
    kind: "Deployment"
    name: "redis"
    apiVersion: "apps/v1"
  metrics:
  - external:
      highWatermark: 400m
      lowWatermark: 150m
      metricName: false.metrics
      metricSelector:
        matchLabels:
          kube_deployment: redis
          short_image: redis
    type: External
  tolerance: "0.01"
```

by default the WPA will be in `dryrun:false`
update the `wpa.spec.dryRun` with `./bin/kubectl-wpa dry-run enable example1-watermarkpodautoscaler`

the status should be updated like

```
➜ k get wpa
NAME                              CONDITION   CONDITION STATUS   VALUE   HIGH WATERMARK   LOW WATERMARK   AGE    MIN REPLICAS   MAX REPLICAS   DRY-RUN   LAST SCALE
example1-watermarkpodautoscaler   DryRun      True                       400m             150m            117m   4              9              True      96m
```