### PR TITLE
fix(wpa_char): convert crd object from v1beta1 to v1

### DIFF
--- a/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd.yaml
+++ b/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -6,28 +6,6 @@ metadata:
   creationTimestamp: null
   name: watermarkpodautoscalers.datadoghq.com
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.currentMetrics[*].external.currentValue..
-    name: value
-    type: string
-  - JSONPath: .spec.metrics[*].external.highWatermark..
-    name: high watermark
-    type: string
-  - JSONPath: .spec.metrics[*].external.lowWatermark..
-    name: low watermark
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: age
-    type: date
-  - JSONPath: .spec.minReplicas
-    name: min replicas
-    type: integer
-  - JSONPath: .spec.maxReplicas
-    name: max replicas
-    type: integer
-  - JSONPath: .spec.dryRun
-    name: dry-run
-    type: string
   group: datadoghq.com
   names:
     kind: WatermarkPodAutoscaler
@@ -37,647 +15,680 @@ spec:
     - wpa
     singular: watermarkpodautoscaler
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: WatermarkPodAutoscaler is the Schema for the watermarkpodautoscalers
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: WatermarkPodAutoscalerSpec defines the desired state of WatermarkPodAutoscaler
-          properties:
-            algorithm:
-              description: 'computed values take the # of replicas into account'
-              type: string
-            downscaleForbiddenWindowSeconds:
-              description: 'part of HorizontalController, see comments in the k8s
-                repo: pkg/controller/podautoscaler/horizontal.go'
-              format: int32
-              minimum: 1
-              type: integer
-            dryRun:
-              description: Whether planned scale changes are actually applied
-              type: boolean
-            maxReplicas:
-              format: int32
-              minimum: 1
-              type: integer
-            metrics:
-              description: specifications that will be used to calculate the desired
-                replica count
-              items:
-                description: MetricSpec specifies how to scale based on a single metric
-                  (only `type` and one other matching field should be set at once).
-                properties:
-                  external:
-                    description: external refers to a global metric that is not associated
-                      with any Kubernetes object. It allows autoscaling based on information
-                      coming from components running outside of cluster (for example
-                      length of queue in cloud messaging service, or QPS from loadbalancer
-                      running outside of cluster).
-                    properties:
-                      highWatermark:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      lowWatermark:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      metricName:
-                        description: metricName is the name of the metric in question.
-                        type: string
-                      metricSelector:
-                        description: metricSelector is used to identify a specific
-                          time series within a given metric.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                    required:
-                    - metricName
-                    type: object
-                  resource:
-                    description: resource refers to a resource metric (such as those
-                      specified in requests and limits) known to Kubernetes describing
-                      each pod in the current scale target (e.g. CPU or memory). Such
-                      metrics are built in to Kubernetes, and have special scaling
-                      options on top of those available to normal per-pod metrics
-                      using the "pods" source.
-                    properties:
-                      highWatermark:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      lowWatermark:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      metricSelector:
-                        description: metricSelector is used to identify a specific
-                          time series within a given metric.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      name:
-                        description: name is the name of the resource in question.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type:
-                    description: type is the type of metric source.  It should be
-                      one of "Object", "Pods" or "Resource", each mapping to a matching
-                      field in the object.
-                    type: string
-                required:
-                - type
-                type: object
-              type: array
-            minReplicas:
-              format: int32
-              minimum: 1
-              type: integer
-            readinessDelaySeconds:
-              format: int32
-              minimum: 1
-              type: integer
-            replicaScalingAbsoluteModulo:
-              description: Number of replicas to scale by at a time. When set, replicas
-                added or removed must be a multiple of this parameter. Allows for
-                special scaling patterns, for instance when an application requires
-                a certain number of pods in multiple
-              format: int32
-              minimum: 1
-              type: integer
-            scaleDownLimitFactor:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Percentage of replicas that can be removed in an downscale
-                event. Parameter used to be a float, in order to support the transition
-                seamlessly, we validate that it is [0;100[ in the code. ScaleDownLimitFactor
-                == 0 means that downscaling will not be allowed for the target.
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-            scaleTargetRef:
-              description: 'part of HorizontalPodAutoscalerSpec, see comments in the
-                k8s-1.10.8 repo: staging/src/k8s.io/api/autoscaling/v1/types.go reference
-                to scaled resource; horizontal pod autoscaler will learn the current
-                resource consumption and will set the desired number of pods by using
-                its Scale subresource.'
-              properties:
-                apiVersion:
-                  description: API version of the referent
-                  type: string
-                kind:
-                  description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"'
-                  type: string
-                name:
-                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                  type: string
-              required:
-              - kind
-              - name
-              type: object
-            scaleUpLimitFactor:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Percentage of replicas that can be added in an upscale
-                event. Parameter used to be a float, in order to support the transition
-                seamlessly, we validate that it is [0;100] in the code. ScaleUpLimitFactor
-                == 0 means that upscaling will not be allowed for the target.
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-            tolerance:
-              anyOf:
-              - type: integer
-              - type: string
-              description: Parameter used to be a float, in order to support the transition
-                seamlessly, we validate that it is ]0;1[ in the code.
-              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-            upscaleForbiddenWindowSeconds:
-              format: int32
-              minimum: 1
-              type: integer
-          required:
-          - scaleTargetRef
-          type: object
-        status:
-          description: WatermarkPodAutoscalerStatus defines the observed state of
-            WatermarkPodAutoscaler
-          properties:
-            conditions:
-              items:
-                description: HorizontalPodAutoscalerCondition describes the state
-                  of a HorizontalPodAutoscaler at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: lastTransitionTime is the last time the condition
-                      transitioned from one status to another
-                    format: date-time
-                    type: string
-                  message:
-                    description: message is a human-readable explanation containing
-                      details about the transition
-                    type: string
-                  reason:
-                    description: reason is the reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: status is the status of the condition (True, False,
-                      Unknown)
-                    type: string
-                  type:
-                    description: type describes the current condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            currentMetrics:
-              items:
-                description: MetricStatus describes the last-read state of a single
-                  metric.
-                properties:
-                  containerResource:
-                    description: container resource refers to a resource metric (such
-                      as those specified in requests and limits) known to Kubernetes
-                      describing a single container in each pod in the current scale
-                      target (e.g. CPU or memory). Such metrics are built in to Kubernetes,
-                      and have special scaling options on top of those available to
-                      normal per-pod metrics using the "pods" source.
-                    properties:
-                      container:
-                        description: container is the name of the container in the
-                          pods of the scaling target
-                        type: string
-                      currentAverageUtilization:
-                        description: currentAverageUtilization is the current value
-                          of the average of the resource metric across all relevant
-                          pods, represented as a percentage of the requested value
-                          of the resource for the pods.  It will only be present if
-                          `targetAverageValue` was set in the corresponding metric
-                          specification.
-                        format: int32
-                        type: integer
-                      currentAverageValue:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: currentAverageValue is the current value of the
-                          average of the resource metric across all relevant pods,
-                          as a raw value (instead of as a percentage of the request),
-                          similar to the "pods" metric source type. It will always
-                          be set, regardless of the corresponding metric specification.
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      name:
-                        description: name is the name of the resource in question.
-                        type: string
-                    required:
-                    - container
-                    - currentAverageValue
-                    - name
-                    type: object
-                  external:
-                    description: external refers to a global metric that is not associated
-                      with any Kubernetes object. It allows autoscaling based on information
-                      coming from components running outside of cluster (for example
-                      length of queue in cloud messaging service, or QPS from loadbalancer
-                      running outside of cluster).
-                    properties:
-                      currentAverageValue:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: currentAverageValue is the current value of metric
-                          averaged over autoscaled pods.
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      currentValue:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: currentValue is the current value of the metric
-                          (as a quantity)
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      metricName:
-                        description: metricName is the name of a metric used for autoscaling
-                          in metric system.
-                        type: string
-                      metricSelector:
-                        description: metricSelector is used to identify a specific
-                          time series within a given metric.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                    required:
-                    - currentValue
-                    - metricName
-                    type: object
-                  object:
-                    description: object refers to a metric describing a single kubernetes
-                      object (for example, hits-per-second on an Ingress object).
-                    properties:
-                      averageValue:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: averageValue is the current value of the average
-                          of the metric across all relevant pods (as a quantity)
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      currentValue:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: currentValue is the current value of the metric
-                          (as a quantity).
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      metricName:
-                        description: metricName is the name of the metric in question.
-                        type: string
-                      selector:
-                        description: selector is the string-encoded form of a standard
-                          kubernetes label selector for the given metric When set
-                          in the ObjectMetricSource, it is passed as an additional
-                          parameter to the metrics server for more specific metrics
-                          scoping. When unset, just the metricName will be used to
-                          gather metrics.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                      target:
-                        description: target is the described Kubernetes object.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent
-                            type: string
-                          kind:
-                            description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                            type: string
-                          name:
-                            description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                            type: string
-                        required:
-                        - kind
-                        - name
-                        type: object
-                    required:
-                    - currentValue
-                    - metricName
-                    - target
-                    type: object
-                  pods:
-                    description: pods refers to a metric describing each pod in the
-                      current scale target (for example, transactions-processed-per-second).  The
-                      values will be averaged together before being compared to the
-                      target value.
-                    properties:
-                      currentAverageValue:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: currentAverageValue is the current value of the
-                          average of the metric across all relevant pods (as a quantity)
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      metricName:
-                        description: metricName is the name of the metric in question
-                        type: string
-                      selector:
-                        description: selector is the string-encoded form of a standard
-                          kubernetes label selector for the given metric When set
-                          in the PodsMetricSource, it is passed as an additional parameter
-                          to the metrics server for more specific metrics scoping.
-                          When unset, just the metricName will be used to gather metrics.
-                        properties:
-                          matchExpressions:
-                            description: matchExpressions is a list of label selector
-                              requirements. The requirements are ANDed.
-                            items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that
-                                relates the key and values.
-                              properties:
-                                key:
-                                  description: key is the label key that the selector
-                                    applies to.
-                                  type: string
-                                operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
-                                  type: string
-                                values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty.
-                                    This array is replaced during a strategic merge
-                                    patch.
-                                  items:
-                                    type: string
-                                  type: array
-                              required:
-                              - key
-                              - operator
-                              type: object
-                            type: array
-                          matchLabels:
-                            additionalProperties:
-                              type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
-                            type: object
-                        type: object
-                    required:
-                    - currentAverageValue
-                    - metricName
-                    type: object
-                  resource:
-                    description: resource refers to a resource metric (such as those
-                      specified in requests and limits) known to Kubernetes describing
-                      each pod in the current scale target (e.g. CPU or memory). Such
-                      metrics are built in to Kubernetes, and have special scaling
-                      options on top of those available to normal per-pod metrics
-                      using the "pods" source.
-                    properties:
-                      currentAverageUtilization:
-                        description: currentAverageUtilization is the current value
-                          of the average of the resource metric across all relevant
-                          pods, represented as a percentage of the requested value
-                          of the resource for the pods.  It will only be present if
-                          `targetAverageValue` was set in the corresponding metric
-                          specification.
-                        format: int32
-                        type: integer
-                      currentAverageValue:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        description: currentAverageValue is the current value of the
-                          average of the resource metric across all relevant pods,
-                          as a raw value (instead of as a percentage of the request),
-                          similar to the "pods" metric source type. It will always
-                          be set, regardless of the corresponding metric specification.
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      name:
-                        description: name is the name of the resource in question.
-                        type: string
-                    required:
-                    - currentAverageValue
-                    - name
-                    type: object
-                  type:
-                    description: 'type is the type of metric source.  It will be one
-                      of "ContainerResource", "External", "Object", "Pods" or "Resource",
-                      each corresponds to a matching field in the object. Note: "ContainerResource"
-                      type is available on when the feature-gate HPAContainerMetrics
-                      is enabled'
-                    type: string
-                required:
-                - type
-                type: object
-              type: array
-            currentReplicas:
-              format: int32
-              type: integer
-            desiredReplicas:
-              format: int32
-              type: integer
-            lastScaleTime:
-              format: date-time
-              type: string
-            observedGeneration:
-              format: int64
-              type: integer
-          required:
-          - currentReplicas
-          - desiredReplicas
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: WatermarkPodAutoscaler is the Schema for the watermarkpodautoscalers
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WatermarkPodAutoscalerSpec defines the desired state of WatermarkPodAutoscaler
+            properties:
+              algorithm:
+                description: 'computed values take the # of replicas into account'
+                type: string
+              downscaleForbiddenWindowSeconds:
+                description: 'part of HorizontalController, see comments in the k8s
+                  repo: pkg/controller/podautoscaler/horizontal.go'
+                format: int32
+                minimum: 1
+                type: integer
+              dryRun:
+                description: Whether planned scale changes are actually applied
+                type: boolean
+              maxReplicas:
+                format: int32
+                minimum: 1
+                type: integer
+              metrics:
+                description: specifications that will be used to calculate the desired
+                  replica count
+                items:
+                  description: MetricSpec specifies how to scale based on a single metric
+                    (only `type` and one other matching field should be set at once).
+                  properties:
+                    external:
+                      description: external refers to a global metric that is not associated
+                        with any Kubernetes object. It allows autoscaling based on information
+                        coming from components running outside of cluster (for example
+                        length of queue in cloud messaging service, or QPS from loadbalancer
+                        running outside of cluster).
+                      properties:
+                        highWatermark:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        lowWatermark:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        metricName:
+                          description: metricName is the name of the metric in question.
+                          type: string
+                        metricSelector:
+                          description: metricSelector is used to identify a specific
+                            time series within a given metric.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In, NotIn,
+                                      Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists or
+                                      DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field is
+                                "key", the operator is "In", and the values array contains
+                                only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - metricName
+                      type: object
+                    resource:
+                      description: resource refers to a resource metric (such as those
+                        specified in requests and limits) known to Kubernetes describing
+                        each pod in the current scale target (e.g. CPU or memory). Such
+                        metrics are built in to Kubernetes, and have special scaling
+                        options on top of those available to normal per-pod metrics
+                        using the "pods" source.
+                      properties:
+                        highWatermark:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        lowWatermark:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        metricSelector:
+                          description: metricSelector is used to identify a specific
+                            time series within a given metric.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In, NotIn,
+                                      Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists or
+                                      DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field is
+                                "key", the operator is "In", and the values array contains
+                                only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        name:
+                          description: name is the name of the resource in question.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type:
+                      description: type is the type of metric source.  It should be
+                        one of "Object", "Pods" or "Resource", each mapping to a matching
+                        field in the object.
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+              minReplicas:
+                format: int32
+                minimum: 1
+                type: integer
+              readinessDelaySeconds:
+                format: int32
+                minimum: 1
+                type: integer
+              replicaScalingAbsoluteModulo:
+                description: Number of replicas to scale by at a time. When set, replicas
+                  added or removed must be a multiple of this parameter. Allows for
+                  special scaling patterns, for instance when an application requires
+                  a certain number of pods in multiple
+                format: int32
+                minimum: 1
+                type: integer
+              scaleDownLimitFactor:
+                x-kubernetes-int-or-string: true
+                anyOf:
+                - type: integer
+                - type: string
+                description: Percentage of replicas that can be removed in an downscale
+                  event. Parameter used to be a float, in order to support the transition
+                  seamlessly, we validate that it is [0;100[ in the code. ScaleDownLimitFactor
+                  == 0 means that downscaling will not be allowed for the target.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              scaleTargetRef:
+                description: 'part of HorizontalPodAutoscalerSpec, see comments in the
+                  k8s-1.10.8 repo: staging/src/k8s.io/api/autoscaling/v1/types.go reference
+                  to scaled resource; horizontal pod autoscaler will learn the current
+                  resource consumption and will set the desired number of pods by using
+                  its Scale subresource.'
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"'
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              scaleUpLimitFactor:
+                x-kubernetes-int-or-string: true
+                anyOf:
+                - type: integer
+                - type: string
+                description: Percentage of replicas that can be added in an upscale
+                  event. Parameter used to be a float, in order to support the transition
+                  seamlessly, we validate that it is [0;100] in the code. ScaleUpLimitFactor
+                  == 0 means that upscaling will not be allowed for the target.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              tolerance:
+                x-kubernetes-int-or-string: true
+                anyOf:
+                - type: integer
+                - type: string
+                description: Parameter used to be a float, in order to support the transition
+                  seamlessly, we validate that it is ]0;1[ in the code.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              upscaleForbiddenWindowSeconds:
+                format: int32
+                minimum: 1
+                type: integer
+            required:
+            - scaleTargetRef
+            type: object
+          status:
+            description: WatermarkPodAutoscalerStatus defines the observed state of
+              WatermarkPodAutoscaler
+            properties:
+              conditions:
+                items:
+                  description: HorizontalPodAutoscalerCondition describes the state
+                    of a HorizontalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human-readable explanation containing
+                        details about the transition
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentMetrics:
+                items:
+                  description: MetricStatus describes the last-read state of a single
+                    metric.
+                  properties:
+                    containerResource:
+                      description: container resource refers to a resource metric (such
+                        as those specified in requests and limits) known to Kubernetes
+                        describing a single container in each pod in the current scale
+                        target (e.g. CPU or memory). Such metrics are built in to Kubernetes,
+                        and have special scaling options on top of those available to
+                        normal per-pod metrics using the "pods" source.
+                      properties:
+                        container:
+                          description: container is the name of the container in the
+                            pods of the scaling target
+                          type: string
+                        currentAverageUtilization:
+                          description: currentAverageUtilization is the current value
+                            of the average of the resource metric across all relevant
+                            pods, represented as a percentage of the requested value
+                            of the resource for the pods.  It will only be present if
+                            `targetAverageValue` was set in the corresponding metric
+                            specification.
+                          format: int32
+                          type: integer
+                        currentAverageValue:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentAverageValue is the current value of the
+                            average of the resource metric across all relevant pods,
+                            as a raw value (instead of as a percentage of the request),
+                            similar to the "pods" metric source type. It will always
+                            be set, regardless of the corresponding metric specification.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        name:
+                          description: name is the name of the resource in question.
+                          type: string
+                      required:
+                      - container
+                      - currentAverageValue
+                      - name
+                      type: object
+                    external:
+                      description: external refers to a global metric that is not associated
+                        with any Kubernetes object. It allows autoscaling based on information
+                        coming from components running outside of cluster (for example
+                        length of queue in cloud messaging service, or QPS from loadbalancer
+                        running outside of cluster).
+                      properties:
+                        currentAverageValue:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentAverageValue is the current value of metric
+                            averaged over autoscaled pods.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        currentValue:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentValue is the current value of the metric
+                            (as a quantity)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        metricName:
+                          description: metricName is the name of a metric used for autoscaling
+                            in metric system.
+                          type: string
+                        metricSelector:
+                          description: metricSelector is used to identify a specific
+                            time series within a given metric.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In, NotIn,
+                                      Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists or
+                                      DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field is
+                                "key", the operator is "In", and the values array contains
+                                only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - currentValue
+                      - metricName
+                      type: object
+                    object:
+                      description: object refers to a metric describing a single kubernetes
+                        object (for example, hits-per-second on an Ingress object).
+                      properties:
+                        averageValue:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: averageValue is the current value of the average
+                            of the metric across all relevant pods (as a quantity)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        currentValue:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentValue is the current value of the metric
+                            (as a quantity).
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        metricName:
+                          description: metricName is the name of the metric in question.
+                          type: string
+                        selector:
+                          description: selector is the string-encoded form of a standard
+                            kubernetes label selector for the given metric When set
+                            in the ObjectMetricSource, it is passed as an additional
+                            parameter to the metrics server for more specific metrics
+                            scoping. When unset, just the metricName will be used to
+                            gather metrics.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In, NotIn,
+                                      Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists or
+                                      DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field is
+                                "key", the operator is "In", and the values array contains
+                                only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        target:
+                          description: target is the described Kubernetes object.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                      required:
+                      - currentValue
+                      - metricName
+                      - target
+                      type: object
+                    pods:
+                      description: pods refers to a metric describing each pod in the
+                        current scale target (for example, transactions-processed-per-second).  The
+                        values will be averaged together before being compared to the
+                        target value.
+                      properties:
+                        currentAverageValue:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentAverageValue is the current value of the
+                            average of the metric across all relevant pods (as a quantity)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        metricName:
+                          description: metricName is the name of the metric in question
+                          type: string
+                        selector:
+                          description: selector is the string-encoded form of a standard
+                            kubernetes label selector for the given metric When set
+                            in the PodsMetricSource, it is passed as an additional parameter
+                            to the metrics server for more specific metrics scoping.
+                            When unset, just the metricName will be used to gather metrics.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In, NotIn,
+                                      Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists or
+                                      DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field is
+                                "key", the operator is "In", and the values array contains
+                                only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - currentAverageValue
+                      - metricName
+                      type: object
+                    resource:
+                      description: resource refers to a resource metric (such as those
+                        specified in requests and limits) known to Kubernetes describing
+                        each pod in the current scale target (e.g. CPU or memory). Such
+                        metrics are built in to Kubernetes, and have special scaling
+                        options on top of those available to normal per-pod metrics
+                        using the "pods" source.
+                      properties:
+                        currentAverageUtilization:
+                          description: currentAverageUtilization is the current value
+                            of the average of the resource metric across all relevant
+                            pods, represented as a percentage of the requested value
+                            of the resource for the pods.  It will only be present if
+                            `targetAverageValue` was set in the corresponding metric
+                            specification.
+                          format: int32
+                          type: integer
+                        currentAverageValue:
+                          x-kubernetes-int-or-string: true
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentAverageValue is the current value of the
+                            average of the resource metric across all relevant pods,
+                            as a raw value (instead of as a percentage of the request),
+                            similar to the "pods" metric source type. It will always
+                            be set, regardless of the corresponding metric specification.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        name:
+                          description: name is the name of the resource in question.
+                          type: string
+                      required:
+                      - currentAverageValue
+                      - name
+                      type: object
+                    type:
+                      description: 'type is the type of metric source.  It will be one
+                        of "ContainerResource", "External", "Object", "Pods" or "Resource",
+                        each corresponds to a matching field in the object. Note: "ContainerResource"
+                        type is available on when the feature-gate HPAContainerMetrics
+                        is enabled'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+              currentReplicas:
+                format: int32
+                type: integer
+              desiredReplicas:
+                format: int32
+                type: integer
+              lastScaleTime:
+                format: date-time
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            required:
+            - currentReplicas
+            - desiredReplicas
+            type: object
+        type: object
+    additionalPrinterColumns:
+      - jsonPath: .status.currentMetrics[*].external.currentValue..
+        name: value
+        type: string
+      - jsonPath: .spec.metrics[*].external.highWatermark..
+        name: high watermark
+        type: string
+      - jsonPath: .spec.metrics[*].external.lowWatermark..
+        name: low watermark
+        type: string
+      - jsonPath: .metadata.creationTimestamp
+        name: age
+        type: date
+      - jsonPath: .spec.minReplicas
+        name: min replicas
+        type: integer
+      - jsonPath: .spec.maxReplicas
+        name: max replicas
+        type: integer
+      - jsonPath: .spec.dryRun
+        name: dry-run
+        type: string
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
### What does this PR do?

convert wpa helm chart crd objet from apiVersion: apiextensions.k8s.io/v1beta1 to apiVersion: apiextensions.k8s.io/v1 

apiextensions.k8s.io/v1beta1 is deprecated in kubernetes 1.22 


### Motivation

What inspired you to submit this pull request?

deploy wpa in kubernetes 1.22

### Additional Notes

Anything else we should know when reviewing?

https://github.com/DataDog/watermarkpodautoscaler/issues/135

### Describe your test plan

Deploy wpa in kubernetes 1.22
Test scale up and scale down
Write there any instructions and details you may have to test your PR.
