### PR TITLE
fix: improves checkOwnerRef func perf

### DIFF
--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -8,7 +8,7 @@ package controllers
 import (
 	"fmt"
 	"math"
-	"regexp"
+	"strings"
 	"time"
 
 	"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
@@ -282,8 +282,6 @@ const (
 	statefulSetKind = "StatefulSet"
 )
 
-var exteractDeploymentNameRegex = regexp.MustCompile("(.*)-.*")
-
 func checkOwnerRef(ownerRef []metav1.OwnerReference, targetName string) bool {
 	for _, o := range ownerRef {
 		if o.Kind != replicaSetKind && o.Kind != statefulSetKind {
@@ -293,7 +291,10 @@ func checkOwnerRef(ownerRef []metav1.OwnerReference, targetName string) bool {
 		mainOwnerRef := o.Name
 		if o.Kind == replicaSetKind {
 			// removes the last section from the replicaSet name to get the deployment name.
-			mainOwnerRef = exteractDeploymentNameRegex.FindStringSubmatch(o.Name)[1]
+			lastIndex := strings.LastIndex(o.Name, "-")
+			if lastIndex > -1 {
+				mainOwnerRef = o.Name[:lastIndex]
+			}
 		}
 		if mainOwnerRef == targetName {
 			return true


### PR DESCRIPTION
### What does this PR do?

Use a more performance approach to retrieve the Deployment name from a ReplicaSet name

### Motivation

What inspired you to submit this pull request?

### Additional Notes
benchmark used to compare it. (thanks @L3n41c)

```
$ go test --bench .
goos: darwin
goarch: amd64
pkg: parse_string_bench
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
Benchmark_parseWithSplit-8   	 9194378	       138.5 ns/op
Benchmark_parseWithRegex-8   	 2668801	       418.2 ns/op
Benchmark_parseLastIndex-8   	330009844	         3.422 ns/op
PASS
ok  	parse_string_bench	4.517s
```

```golang
package main
​
import (
	"regexp"
	"strings"
	"testing"
​
	"github.com/stretchr/testify/assert"
)
​
var re = regexp.MustCompile("(.*)-.*")
​
func parseWithSplit(s string) string {
	sp := strings.Split(s, "-")
	sp = sp[:len(sp)-1]
	return strings.Join(sp, "-")
}
​
func parseWithRegex(s string) string {
	matches := re.FindStringSubmatch(s)
	if len(matches) == 2 {
		return matches[1]
	}
	return ""
}
​
func parseLastIndex(s string) string {
	return s[:strings.LastIndex(s, "-")]
}
​
func Test_parseWithSplit(t *testing.T) {
	assert.Equal(t, parseWithSplit("my-deploy-XXX-YYY"), "my-deploy-XXX")
}
​
func Test_parseWithRegex(t *testing.T) {
	assert.Equal(t, parseWithRegex("my-deploy-XXX-YYY"), "my-deploy-XXX")
}
​
func Test_parseLastIndex(t *testing.T) {
	assert.Equal(t, parseLastIndex("my-deploy-XXX-YYY"), "my-deploy-XXX")
}
​
func Benchmark_parseWithSplit(b *testing.B) {
	for n := 0; n < b.N; n++ {
		parseWithSplit("my-deploy-XXX-YYY")
	}
}
​
func Benchmark_parseWithRegex(b *testing.B) {
	for n := 0; n < b.N; n++ {
		parseWithRegex("my-deploy-XXX-YYY")
	}
}
​
func Benchmark_parseLastIndex(b *testing.B) {
	for n := 0; n < b.N; n++ {
		parseLastIndex("my-deploy-XXX-YYY")
	}
}
```

### Describe your test plan

Write there any instructions and details you may have to test your PR.
