### PR TITLE
Add new CRD to support Kubernetes 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ deploy: manifests kustomize
 manifests: generate-manifests patch-crds
 
 generate-manifests: controller-gen
+	$(CONTROLLER_GEN) crd:trivialVersions=true,crdVersions=v1 rbac:roleName=manager webhook paths="./..." output:crd:artifacts:config=config/crd/bases/v1
 	$(CONTROLLER_GEN) crd:trivialVersions=true,crdVersions=v1beta1 rbac:roleName=manager webhook paths="./..." output:crd:artifacts:config=config/crd/bases/v1beta1
 
 # Run go fmt against code

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -89,7 +89,7 @@ type WatermarkPodAutoscalerSpec struct {
 	ScaleTargetRef CrossVersionObjectReference `json:"scaleTargetRef"`
 	// specifications that will be used to calculate the desired replica count
 	// +optional
-	// +listType=set
+	// +listType=atomic
 	Metrics []MetricSpec `json:"metrics,omitempty"`
 	// +kubebuilder:validation:Minimum=1
 	MinReplicas *int32 `json:"minReplicas,omitempty"`
@@ -192,10 +192,10 @@ type WatermarkPodAutoscalerStatus struct {
 	CurrentReplicas    int32        `json:"currentReplicas"`
 	DesiredReplicas    int32        `json:"desiredReplicas"`
 	// +optional
-	// +listType=set
+	// +listType=atomic
 	CurrentMetrics []autoscalingv2.MetricStatus `json:"currentMetrics,omitempty"`
 	// +optional
-	// +listType=set
+	// +listType=atomic
 	Conditions []autoscalingv2.HorizontalPodAutoscalerCondition `json:"conditions,omitempty"`
 
 	// LastConditionType and LastConditionState are here to provide a clear information in the `kubectl get wpa` output

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -298,7 +298,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 					"metrics": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -383,7 +383,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallb
 					"currentMetrics": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{
@@ -401,7 +401,7 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallb
 					"conditions": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
-								"x-kubernetes-list-type": "set",
+								"x-kubernetes-list-type": "atomic",
 							},
 						},
 						SchemaProps: spec.SchemaProps{

--- a/chart/watermarkpodautoscaler/CHANGELOG.md
+++ b/chart/watermarkpodautoscaler/CHANGELOG.md
@@ -6,3 +6,7 @@
 
 * Migration to Operator SDK 1.0 - Most CLI flags changed
 * This chart should be used with WatermarkPodAutoscaler controller version >= v0.3.0.
+
+### v0.3.1
+
+* Add chart using `apiextensions.k8s.io/v1` for the CRD to support Kubernetes 1.22.

--- a/chart/watermarkpodautoscaler/Chart.yaml
+++ b/chart/watermarkpodautoscaler/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.4.0
 description: Watermark Pod Autoscaler
 name: watermarkpodautoscaler
-version: v0.3.0
+version: v0.3.1

--- a/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd_v1.yaml
+++ b/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd_v1.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1" }}
 
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -736,3 +737,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd_v1beta1.yaml
+++ b/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd_v1beta1.yaml
@@ -1,3 +1,4 @@
+{{- if not (.Capabilities.APIVersions.Has "apiextensions.k8s.io/v1") }}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -529,3 +530,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -1,0 +1,738 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: watermarkpodautoscalers.datadoghq.com
+spec:
+  group: datadoghq.com
+  names:
+    kind: WatermarkPodAutoscaler
+    listKind: WatermarkPodAutoscalerList
+    plural: watermarkpodautoscalers
+    shortNames:
+    - wpa
+    singular: watermarkpodautoscaler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="ScalingActive")].status
+      name: scaling active
+      type: string
+    - jsonPath: .status.lastConditionType
+      name: condition
+      type: string
+    - jsonPath: .status.lastConditionState
+      name: condition state
+      type: string
+    - jsonPath: .status.currentMetrics[*].external.currentValue..
+      name: value
+      type: string
+    - jsonPath: .spec.metrics[*].external.highWatermark..
+      name: high watermark
+      type: string
+    - jsonPath: .spec.metrics[*].external.lowWatermark..
+      name: low watermark
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: age
+      type: date
+    - jsonPath: .spec.minReplicas
+      name: min replicas
+      type: integer
+    - jsonPath: .spec.maxReplicas
+      name: max replicas
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="DryRun")].status
+      name: dry-run
+      type: string
+    - jsonPath: .status.lastScaleTime
+      name: last scale
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: WatermarkPodAutoscaler is the Schema for the watermarkpodautoscalers
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WatermarkPodAutoscalerSpec defines the desired state of WatermarkPodAutoscaler
+            properties:
+              algorithm:
+                description: 'computed values take the # of replicas into account'
+                type: string
+              downscaleForbiddenWindowSeconds:
+                description: 'part of HorizontalController, see comments in the k8s
+                  repo: pkg/controller/podautoscaler/horizontal.go'
+                format: int32
+                minimum: 1
+                type: integer
+              dryRun:
+                description: Whether planned scale changes are actually applied
+                type: boolean
+              maxReplicas:
+                format: int32
+                minimum: 1
+                type: integer
+              metrics:
+                description: specifications that will be used to calculate the desired
+                  replica count
+                items:
+                  description: MetricSpec specifies how to scale based on a single
+                    metric (only `type` and one other matching field should be set
+                    at once).
+                  properties:
+                    external:
+                      description: external refers to a global metric that is not
+                        associated with any Kubernetes object. It allows autoscaling
+                        based on information coming from components running outside
+                        of cluster (for example length of queue in cloud messaging
+                        service, or QPS from loadbalancer running outside of cluster).
+                      properties:
+                        highWatermark:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        lowWatermark:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        metricName:
+                          description: metricName is the name of the metric in question.
+                          type: string
+                        metricSelector:
+                          description: metricSelector is used to identify a specific
+                            time series within a given metric.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - metricName
+                      type: object
+                    resource:
+                      description: resource refers to a resource metric (such as those
+                        specified in requests and limits) known to Kubernetes describing
+                        each pod in the current scale target (e.g. CPU or memory).
+                        Such metrics are built in to Kubernetes, and have special
+                        scaling options on top of those available to normal per-pod
+                        metrics using the "pods" source.
+                      properties:
+                        highWatermark:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        lowWatermark:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        metricSelector:
+                          description: metricSelector is used to identify a specific
+                            time series within a given metric.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        name:
+                          description: name is the name of the resource in question.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type:
+                      description: type is the type of metric source.  It should be
+                        one of "Object", "Pods" or "Resource", each mapping to a matching
+                        field in the object.
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: set
+              minAvailableReplicaPercentage:
+                description: MinAvailableReplicaPercentage indicates the minimum percentage
+                  of replicas that need to be available in order for the controller
+                  to autoscale the target.
+                format: int32
+                maximum: 100
+                type: integer
+              minReplicas:
+                format: int32
+                minimum: 1
+                type: integer
+              readinessDelaySeconds:
+                format: int32
+                minimum: 1
+                type: integer
+              replicaScalingAbsoluteModulo:
+                description: Number of replicas to scale by at a time. When set, replicas
+                  added or removed must be a multiple of this parameter. Allows for
+                  special scaling patterns, for instance when an application requires
+                  a certain number of pods in multiple
+                format: int32
+                minimum: 1
+                type: integer
+              scaleDownLimitFactor:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Percentage of replicas that can be removed in an downscale
+                  event. Parameter used to be a float, in order to support the transition
+                  seamlessly, we validate that it is [0;100[ in the code. ScaleDownLimitFactor
+                  == 0 means that downscaling will not be allowed for the target.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              scaleTargetRef:
+                description: 'part of HorizontalPodAutoscalerSpec, see comments in
+                  the k8s-1.10.8 repo: staging/src/k8s.io/api/autoscaling/v1/types.go
+                  reference to scaled resource; horizontal pod autoscaler will learn
+                  the current resource consumption and will set the desired number
+                  of pods by using its Scale subresource.'
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds"'
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              scaleUpLimitFactor:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Percentage of replicas that can be added in an upscale
+                  event. Parameter used to be a float, in order to support the transition
+                  seamlessly, we validate that it is [0;100] in the code. ScaleUpLimitFactor
+                  == 0 means that upscaling will not be allowed for the target.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              tolerance:
+                anyOf:
+                - type: integer
+                - type: string
+                description: Parameter used to be a float, in order to support the
+                  transition seamlessly, we validate that it is ]0;1[ in the code.
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
+              upscaleForbiddenWindowSeconds:
+                format: int32
+                minimum: 1
+                type: integer
+            required:
+            - scaleTargetRef
+            type: object
+          status:
+            description: WatermarkPodAutoscalerStatus defines the observed state of
+              WatermarkPodAutoscaler
+            properties:
+              conditions:
+                items:
+                  description: HorizontalPodAutoscalerCondition describes the state
+                    of a HorizontalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human-readable explanation containing
+                        details about the transition
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: set
+              currentMetrics:
+                items:
+                  description: MetricStatus describes the last-read state of a single
+                    metric.
+                  properties:
+                    containerResource:
+                      description: container resource refers to a resource metric
+                        (such as those specified in requests and limits) known to
+                        Kubernetes describing a single container in each pod in the
+                        current scale target (e.g. CPU or memory). Such metrics are
+                        built in to Kubernetes, and have special scaling options on
+                        top of those available to normal per-pod metrics using the
+                        "pods" source.
+                      properties:
+                        container:
+                          description: container is the name of the container in the
+                            pods of the scaling target
+                          type: string
+                        currentAverageUtilization:
+                          description: currentAverageUtilization is the current value
+                            of the average of the resource metric across all relevant
+                            pods, represented as a percentage of the requested value
+                            of the resource for the pods.  It will only be present
+                            if `targetAverageValue` was set in the corresponding metric
+                            specification.
+                          format: int32
+                          type: integer
+                        currentAverageValue:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentAverageValue is the current value of
+                            the average of the resource metric across all relevant
+                            pods, as a raw value (instead of as a percentage of the
+                            request), similar to the "pods" metric source type. It
+                            will always be set, regardless of the corresponding metric
+                            specification.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        name:
+                          description: name is the name of the resource in question.
+                          type: string
+                      required:
+                      - container
+                      - currentAverageValue
+                      - name
+                      type: object
+                    external:
+                      description: external refers to a global metric that is not
+                        associated with any Kubernetes object. It allows autoscaling
+                        based on information coming from components running outside
+                        of cluster (for example length of queue in cloud messaging
+                        service, or QPS from loadbalancer running outside of cluster).
+                      properties:
+                        currentAverageValue:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentAverageValue is the current value of
+                            metric averaged over autoscaled pods.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        currentValue:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentValue is the current value of the metric
+                            (as a quantity)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        metricName:
+                          description: metricName is the name of a metric used for
+                            autoscaling in metric system.
+                          type: string
+                        metricSelector:
+                          description: metricSelector is used to identify a specific
+                            time series within a given metric.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - currentValue
+                      - metricName
+                      type: object
+                    object:
+                      description: object refers to a metric describing a single kubernetes
+                        object (for example, hits-per-second on an Ingress object).
+                      properties:
+                        averageValue:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: averageValue is the current value of the average
+                            of the metric across all relevant pods (as a quantity)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        currentValue:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentValue is the current value of the metric
+                            (as a quantity).
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        metricName:
+                          description: metricName is the name of the metric in question.
+                          type: string
+                        selector:
+                          description: selector is the string-encoded form of a standard
+                            kubernetes label selector for the given metric When set
+                            in the ObjectMetricSource, it is passed as an additional
+                            parameter to the metrics server for more specific metrics
+                            scoping. When unset, just the metricName will be used
+                            to gather metrics.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        target:
+                          description: target is the described Kubernetes object.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent
+                              type: string
+                            kind:
+                              description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                              type: string
+                            name:
+                              description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                              type: string
+                          required:
+                          - kind
+                          - name
+                          type: object
+                      required:
+                      - currentValue
+                      - metricName
+                      - target
+                      type: object
+                    pods:
+                      description: pods refers to a metric describing each pod in
+                        the current scale target (for example, transactions-processed-per-second).  The
+                        values will be averaged together before being compared to
+                        the target value.
+                      properties:
+                        currentAverageValue:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentAverageValue is the current value of
+                            the average of the metric across all relevant pods (as
+                            a quantity)
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        metricName:
+                          description: metricName is the name of the metric in question
+                          type: string
+                        selector:
+                          description: selector is the string-encoded form of a standard
+                            kubernetes label selector for the given metric When set
+                            in the PodsMetricSource, it is passed as an additional
+                            parameter to the metrics server for more specific metrics
+                            scoping. When unset, just the metricName will be used
+                            to gather metrics.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                      required:
+                      - currentAverageValue
+                      - metricName
+                      type: object
+                    resource:
+                      description: resource refers to a resource metric (such as those
+                        specified in requests and limits) known to Kubernetes describing
+                        each pod in the current scale target (e.g. CPU or memory).
+                        Such metrics are built in to Kubernetes, and have special
+                        scaling options on top of those available to normal per-pod
+                        metrics using the "pods" source.
+                      properties:
+                        currentAverageUtilization:
+                          description: currentAverageUtilization is the current value
+                            of the average of the resource metric across all relevant
+                            pods, represented as a percentage of the requested value
+                            of the resource for the pods.  It will only be present
+                            if `targetAverageValue` was set in the corresponding metric
+                            specification.
+                          format: int32
+                          type: integer
+                        currentAverageValue:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: currentAverageValue is the current value of
+                            the average of the resource metric across all relevant
+                            pods, as a raw value (instead of as a percentage of the
+                            request), similar to the "pods" metric source type. It
+                            will always be set, regardless of the corresponding metric
+                            specification.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        name:
+                          description: name is the name of the resource in question.
+                          type: string
+                      required:
+                      - currentAverageValue
+                      - name
+                      type: object
+                    type:
+                      description: 'type is the type of metric source.  It will be
+                        one of "ContainerResource", "External", "Object", "Pods" or
+                        "Resource", each corresponds to a matching field in the object.
+                        Note: "ContainerResource" type is available on when the feature-gate
+                        HPAContainerMetrics is enabled'
+                      type: string
+                  required:
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-type: set
+              currentReplicas:
+                format: int32
+                type: integer
+              desiredReplicas:
+                format: int32
+                type: integer
+              lastConditionState:
+                description: LastConditionType correspond to the last condition state
+                  (True,False) updated in the WPA status during the WPA reconcile
+                  state.
+                type: string
+              lastConditionType:
+                description: LastConditionType correspond to the last condition type
+                  updated in the WPA status during the WPA reconcile state.
+                type: string
+              lastScaleTime:
+                format: date-time
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            required:
+            - currentReplicas
+            - desiredReplicas
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
### What does this PR do?

Add a new CRD to support 1.22. Update the chart.
Following the same pattern of the Datadog-Operator.
The chart will be moved to the [Datadog Helm Repo](https://github.com/DataDog/helm-charts) next.

### Motivation

Support users in Kubernetes 1.22
Issue initially brought up by our users https://github.com/DataDog/watermarkpodautoscaler/issues/135 

### Additional Notes

I had to move list types from set to atomic. 
Discuss if you believe this will have unintended effects.
Had to do it as x-kubernetes-types are supposed to be supported with k8s 1.16, so I did not want to just patch the chart (like we do for v1beta1). Set did not pass:
```
Error: INSTALLATION FAILED: CustomResourceDefinition.apiextensions.k8s.io "watermarkpodautoscalers.datadoghq.com" is invalid: spec.validation.openAPIV3Schema.properties[status].properties[currentMetrics].items.x-kubernetes-map-type: Invalid value: "null": must be atomic as item of a list with x-kubernetes-list-type=set
```

### Describe your test plan

Create the chart in Kubernetes 1.22, confirm it uses the CRD v1 and with a version < 1.22 that it uses v1beta1 (not a breaking change).
