### PR TITLE
[Draft] Add support for limiting downscale/upscale until metrics has evaluated below/above watermark for duration

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -193,10 +193,12 @@ type MetricSpec struct {
 // WatermarkPodAutoscalerStatus defines the observed state of WatermarkPodAutoscaler
 // +k8s:openapi-gen=true
 type WatermarkPodAutoscalerStatus struct {
-	ObservedGeneration *int64       `json:"observedGeneration,omitempty"`
-	LastScaleTime      *metav1.Time `json:"lastScaleTime,omitempty"`
-	CurrentReplicas    int32        `json:"currentReplicas"`
-	DesiredReplicas    int32        `json:"desiredReplicas"`
+	ObservedGeneration         *int64       `json:"observedGeneration,omitempty"`
+	LastScaleTime              *metav1.Time `json:"lastScaleTime,omitempty"`
+	LastTimeAboveLowWatermark  *metav1.Time `json:"lastTimeAboveLowWatermark,omitempty"`
+	LastTimeBelowHighWatermark *metav1.Time `json:"lastTimeBelowHighWatermark,omitempty"`
+	CurrentReplicas            int32        `json:"currentReplicas"`
+	DesiredReplicas            int32        `json:"desiredReplicas"`
 	// +optional
 	// +listType=atomic
 	CurrentMetrics []autoscalingv2.MetricStatus `json:"currentMetrics,omitempty"`

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -63,7 +63,7 @@ type WatermarkPodAutoscalerSpec struct {
 	UpscaleForbiddenWindowSeconds int32 `json:"upscaleForbiddenWindowSeconds,omitempty"`
 
 	// +kubebuilder:validation:Minimum=0
-	UpEvaluateUpWatermarkSeconds int32 `json:"upEvaluateUpWatermarkSeconds,omitempty"`
+	UpscaleEvaluateAboveWatermarkSeconds int32 `json:"upscaleEvaluateAboveWatermarkSeconds,omitempty"`
 
 	// Percentage of replicas that can be added in an upscale event.
 	// Parameter used to be a float, in order to support the transition seamlessly, we validate that it is [0;100] in the code.

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -56,8 +56,14 @@ type WatermarkPodAutoscalerSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	DownscaleForbiddenWindowSeconds int32 `json:"downscaleForbiddenWindowSeconds,omitempty"`
 
+	// +kubebuilder:validation:Minimum=0
+	DownscaleEvaluateBelowWatermarkSeconds int32 `json:"downscaleEvaluateBelowWatermarkSeconds,omitempty"`
+
 	// +kubebuilder:validation:Minimum=1
 	UpscaleForbiddenWindowSeconds int32 `json:"upscaleForbiddenWindowSeconds,omitempty"`
+
+	// +kubebuilder:validation:Minimum=0
+	UpEvaluateUpWatermarkSeconds int32 `json:"upEvaluateUpWatermarkSeconds,omitempty"`
 
 	// Percentage of replicas that can be added in an upscale event.
 	// Parameter used to be a float, in order to support the transition seamlessly, we validate that it is [0;100] in the code.

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -945,10 +945,12 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 	logf.SetLogger(zap.New())
 
 	type args struct {
-		wpa             *v1alpha1.WatermarkPodAutoscaler
-		currentReplicas int32
-		desiredReplicas int32
-		timestamp       time.Time
+		wpa                        *v1alpha1.WatermarkPodAutoscaler
+		currentReplicas            int32
+		desiredReplicas            int32
+		timestamp                  time.Time
+		lastTimeAboveLowWatermark  time.Time
+		lastTimeBelowHighWatermark time.Time
 	}
 
 	tests := []struct {
@@ -1047,7 +1049,14 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			scale := shouldScale(logf.Log.WithName(tt.name), tt.args.wpa, tt.args.currentReplicas, tt.args.desiredReplicas, tt.args.timestamp)
+			scale := shouldScale(
+				logf.Log.WithName(tt.name),
+				tt.args.wpa,
+				tt.args.currentReplicas,
+				tt.args.desiredReplicas,
+				tt.args.timestamp,
+				tt.args.lastTimeAboveLowWatermark,
+				tt.args.lastTimeBelowHighWatermark)
 			if scale != tt.shoudScale {
 				t.Error("Incorrect scale")
 			}

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -945,12 +945,10 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 	logf.SetLogger(zap.New())
 
 	type args struct {
-		wpa                        *v1alpha1.WatermarkPodAutoscaler
-		currentReplicas            int32
-		desiredReplicas            int32
-		timestamp                  time.Time
-		lastTimeAboveLowWatermark  time.Time
-		lastTimeBelowHighWatermark time.Time
+		wpa             *v1alpha1.WatermarkPodAutoscaler
+		currentReplicas int32
+		desiredReplicas int32
+		timestamp       time.Time
 	}
 
 	tests := []struct {
@@ -1061,10 +1059,10 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 						DownscaleEvaluateBelowWatermarkSeconds: 10,
 					},
 					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
-						LastScaleTime: &metav1.Time{Time: time.Unix(10, 0)},
+						LastScaleTime:             &metav1.Time{Time: time.Unix(10, 0)},
+						LastTimeAboveLowWatermark: &metav1.Time{Time: time.Unix(9, 0)},
 					},
 				}),
-				lastTimeAboveLowWatermark: time.Unix(9, 0),
 			},
 			shoudScale: true,
 		},
@@ -1081,10 +1079,10 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 						DownscaleEvaluateBelowWatermarkSeconds: 10,
 					},
 					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
-						LastScaleTime: &metav1.Time{Time: time.Unix(10, 0)},
+						LastScaleTime:             &metav1.Time{Time: time.Unix(10, 0)},
+						LastTimeAboveLowWatermark: &metav1.Time{Time: time.Unix(18, 0)},
 					},
 				}),
-				lastTimeAboveLowWatermark: time.Unix(18, 0),
 			},
 			shoudScale: false,
 		},
@@ -1102,10 +1100,10 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 						UpscaleEvaluateAboveWatermarkSeconds: 10,
 					},
 					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
-						LastScaleTime: &metav1.Time{Time: time.Unix(10, 0)},
+						LastScaleTime:              &metav1.Time{Time: time.Unix(10, 0)},
+						LastTimeBelowHighWatermark: &metav1.Time{Time: time.Unix(9, 0)},
 					},
 				}),
-				lastTimeBelowHighWatermark: time.Unix(9, 0),
 			},
 			shoudScale: true,
 		},
@@ -1122,10 +1120,10 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 						UpscaleEvaluateAboveWatermarkSeconds: 10,
 					},
 					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
-						LastScaleTime: &metav1.Time{Time: time.Unix(10, 0)},
+						LastScaleTime:              &metav1.Time{Time: time.Unix(10, 0)},
+						LastTimeBelowHighWatermark: &metav1.Time{Time: time.Unix(18, 0)},
 					},
 				}),
-				lastTimeBelowHighWatermark: time.Unix(18, 0),
 			},
 			shoudScale: false,
 		},
@@ -1137,9 +1135,7 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 				tt.args.wpa,
 				tt.args.currentReplicas,
 				tt.args.desiredReplicas,
-				tt.args.timestamp,
-				tt.args.lastTimeAboveLowWatermark,
-				tt.args.lastTimeBelowHighWatermark)
+				tt.args.timestamp)
 			if scale != tt.shoudScale {
 				t.Error("Incorrect scale")
 			}


### PR DESCRIPTION
### What does this PR do?

This P.R adds support for additional configuration options that allow downscales/upscales to be constrained until the metric has evaluated below (or above) the corresponding watermark for a configurable duration. This will be useful for slowing down downscales and preventing downscales from occurring immediately as soon as a value drops below the low watermark which will improve reliability by preventing downscales during dependency failures and minor stalls.

### Motivation

We've had several issues where one of our dependencies temporarily fails and this causes the CPU of our service to dip which results in downscales which makes the subsequent recovery more difficult when the dependency is restored.