### PR TITLE
Adding logic to skip delay if feature is not enabled

### DIFF
--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -413,6 +413,11 @@ func shouldScale(logger logr.Logger, wpa *datadoghqv1alpha1.WatermarkPodAutoscal
 }
 
 func canScale(logger logr.Logger, isBackoff bool, wasOutOfBounds autoscalingv2.HorizontalPodAutoscalerCondition, decisionDelay int32) bool {
+	// feature is disabled
+	if decisionDelay == 0 {
+		return !isBackoff
+	}
+
 	now := metav1.Now()
 	canScaleDelay := decisionDelay - int32(now.Sub(wasOutOfBounds.LastTransitionTime.Time).Seconds())
 	if canScaleDelay > 0 || wasOutOfBounds.Status != corev1.ConditionTrue {

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -1214,7 +1214,7 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 					},
 					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
 						LastScaleTime: &metav1.Time{Time: time.Unix(1232000, 0)},
-						// no need to check canScaleDelay as we keep the same number of replicas
+						// no need to check scaleDelay as we keep the same number of replicas
 					},
 				}),
 			},
@@ -1278,8 +1278,9 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 				timestamp:       time.Unix(1232599, 0), // TODO FIXME
 				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
 					Spec: &v1alpha1.WatermarkPodAutoscalerSpec{
-						UpscaleForbiddenWindowSeconds:   60,
-						DownscaleForbiddenWindowSeconds: 60,
+						UpscaleForbiddenWindowSeconds:     60,
+						DownscaleForbiddenWindowSeconds:   60,
+						UpscaleDelayAboveWatermarkSeconds: 10, // non null to make sure the feature is activated
 					},
 					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
 						LastScaleTime: &metav1.Time{Time: time.Unix(1232000, 0)},


### PR DESCRIPTION
### What does this PR do?

The delay feature does not support WPAs with multi metrics, however the feature did introduce a breaking change as it prevents scaling because a condition is added in the WPA status to reflect that the last metric evaluated was out of bounds or not.
The nominal behavior with mutli metrics is to allow scaling events even if one of the metrics is within the bounds.

### Motivation

fix bug introduced in 0.5.0.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
