### PR TITLE
Updating go version to 1.18.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/watermarkpodautoscaler
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
### What does this PR do?

bump golang to avoid triggering CVE-2022-27664

```
 ➜  watermarkpodautoscaler git:(charlyf/bump-golang-1.18.6) ✗ kl watermarkpodautoscaler-66588497d4-knb2w -f
{"level":"info","ts":1663104344151.1304,"logger":"setup","msg":"Version: 0.5.2-rc.1_adb45b8"}
{"level":"info","ts":1663104344151.2458,"logger":"setup","msg":"Build time: 2022-09-13/17:22:40"}
{"level":"info","ts":1663104344151.2568,"logger":"setup","msg":"Git tag: "}
{"level":"info","ts":1663104344151.2673,"logger":"setup","msg":"Git Commit: adb45b8842d9258e76becbcaf33a9c5b5eae3c88"}
{"level":"info","ts":1663104344151.2825,"logger":"setup","msg":"Go Version: go1.18.6"}
```
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
