### PR TITLE
Add `Spec.ConvergeTowardsHighWatermark`

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -80,6 +80,10 @@ type WatermarkPodAutoscalerSpec struct {
 	// +kubebuilder:validation:Minimum=1
 	ReplicaScalingAbsoluteModulo *int32 `json:"replicaScalingAbsoluteModulo,omitempty"`
 
+	// Try to make the usage converge towards High Watermark to save resources. This will slowly downscale by `ReplicaScalingAbsoluteModulo`
+	// if the predicted usage stays bellow the high watermarks.
+	ConvergeTowardsHighWatermark bool `json:"convergeTowardsHighWatermark,omitempty"`
+
 	// Parameter used to be a float, in order to support the transition seamlessly, we validate that it is ]0;1[ in the code.
 	Tolerance resource.Quantity `json:"tolerance,omitempty"`
 
@@ -220,6 +224,9 @@ const WatermarkPodAutoscalerStatusBelowLowWatermark autoscalingv2.HorizontalPodA
 
 // WatermarkPodAutoscalerStatusAboveHighWatermark ConditionType used when the value is above the high watermark
 const WatermarkPodAutoscalerStatusAboveHighWatermark autoscalingv2.HorizontalPodAutoscalerConditionType = "AboveHighWatermark"
+
+// WatermarkPodAutoscalerStatusConvergeToHighWatermark ConditionType used when the value is within bound and we're trying to converge to the high watermark
+const WatermarkPodAutoscalerStatusConvergeToHighWatermark autoscalingv2.HorizontalPodAutoscalerConditionType = "ConvergeToHighWatermark"
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -280,6 +280,13 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 							Format:      "int32",
 						},
 					},
+					"convergeTowardsHighWatermark": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Try to make the usage converge towards High Watermark to save resources. This will slowly downscale by `ReplicaScalingAbsoluteModulo` if the predicted usage stays bellow the high watermarks.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"tolerance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameter used to be a float, in order to support the transition seamlessly, we validate that it is ]0;1[ in the code.",

--- a/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -73,6 +73,11 @@ spec:
           spec:
             description: WatermarkPodAutoscalerSpec defines the desired state of WatermarkPodAutoscaler
             properties:
+              ConvergeTowardsHighWatermark:
+                description: Try to make the usage converge towards High Watermark
+                  to save resources. This will slowly downscale by `ReplicaScalingAbsoluteModulo`
+                  if the predicted usage stays bellow the high watermarks.
+                type: boolean
               algorithm:
                 description: 'computed values take the # of replicas into account'
                 type: string

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -71,6 +71,11 @@ spec:
         spec:
           description: WatermarkPodAutoscalerSpec defines the desired state of WatermarkPodAutoscaler
           properties:
+            ConvergeTowardsHighWatermark:
+              description: Try to make the usage converge towards High Watermark to
+                save resources. This will slowly downscale by `ReplicaScalingAbsoluteModulo`
+                if the predicted usage stays bellow the high watermarks.
+              type: boolean
             algorithm:
               description: 'computed values take the # of replicas into account'
               type: string

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -286,7 +286,7 @@ func tryToConvergeToHw(logger logr.Logger, currentReplicas, currentReadyReplicas
 	setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusConvergeToHighWatermark, corev1.ConditionTrue, convergeToHighWatermarkAllowedMessage, convergeToHighWatermarkAllowedReason)
 
 	// This should stay under HW
-	logger.Info("Trying to scale down to convert to HW", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "currentReplicasAfterDownscale", currentReplicasAfterDownscale, "currentReadyReplicasAfterDownscale", currentReadyReplicasAfterDownscale, "adjustedUsageAfterDownscale", adjustedUsageAfterDownscale, "highMark", highMark.MilliValue())
+	logger.Info("Trying to scale down to converge to HW", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "currentReplicasAfterDownscale", currentReplicasAfterDownscale, "currentReadyReplicasAfterDownscale", currentReadyReplicasAfterDownscale, "adjustedUsageAfterDownscale", adjustedUsageAfterDownscale, "highMark", highMark.MilliValue())
 	return currentReplicasAfterDownscale
 }
 

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -266,8 +266,7 @@ func getReplicaCountWithinBounds(currentReplicas int32, wpa *v1alpha1.WatermarkP
 }
 
 // tryToConvergeToHw will try to make the replicaCount slowly converge to high watermark but make sure that it does
-//
-//	not trigger a downscale that would put usage above HW
+// not trigger a downscale that would put usage above HW
 func tryToConvergeToHw(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, adjustedUsage float64, lowMark, highMark *resource.Quantity) (replicaCount int32) {
 
 	downScaleBy := *wpa.Spec.ReplicaScalingAbsoluteModulo

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -492,7 +492,7 @@ func TestScaleIntervalReplicaCalcConvergeScaleDown(t *testing.T) {
 		metric: &metricInfo{
 			spec:                metric1,
 			levels:              []int64{8000, 8000, 8000}, // We are between the high and low watermarks.
-			expectedUtilization: 27000,
+			expectedUtilization: 24000,
 		},
 	}
 	tc.runTest(t)

--- a/pkg/math32/math32.go
+++ b/pkg/math32/math32.go
@@ -1,0 +1,22 @@
+package math32
+
+import "math"
+
+func Max(x, y int32) int32 {
+	if x < y {
+		return y
+	}
+	return x
+}
+
+func Floor(a float64) int32 {
+	return int32(math.Floor(a))
+}
+
+func Ceil(a float64) int32 {
+	return int32(math.Ceil(a))
+}
+
+func Mod(x int32, y int32) int32 {
+	return int32(math.Mod(float64(x), float64(y)))
+}

--- a/pkg/math32/math32.go
+++ b/pkg/math32/math32.go
@@ -2,6 +2,7 @@ package math32
 
 import "math"
 
+// Max returns the maximum of y and x.
 func Max(x, y int32) int32 {
 	if x < y {
 		return y
@@ -9,14 +10,17 @@ func Max(x, y int32) int32 {
 	return x
 }
 
+// Floor returns the greatest integer value less than or equal to x.
 func Floor(a float64) int32 {
 	return int32(math.Floor(a))
 }
 
+// Ceil returns the least integer value greater than or equal to x.
 func Ceil(a float64) int32 {
 	return int32(math.Ceil(a))
 }
 
+// Mod returns the floating-point remainder of x/y.
 func Mod(x int32, y int32) int32 {
 	return int32(math.Mod(float64(x), float64(y)))
 }


### PR DESCRIPTION
LW/HW are supposed to reduce oscillations, but when you have 1000 replicas with 20% between LW and HW you often end up with more than a hundred un-needed replicas.

Setting `Spec.ConvergeTowardsHighWatermark` will slowly downscale by `Spec.ReplicaScalingAbsoluteModulo` at a time, and only if the forecasted usage stays bellow the highwatermark.

The existing scale down cooldown mechanisms will be respected.
