### PR TITLE
Add the possibility to configure the api-server client timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 	var logEncoder string
 	var logTimestampFormat string
 	var syncPeriodSeconds int
+	var clientTimeoutDuration time.Duration
 	var leaderElectionResourceLock string
 	var ddProfilingEnabled bool
 	var workers int
@@ -66,7 +67,8 @@ func main() {
 	flag.IntVar(&healthPort, "health-port", healthPort, "Port to use for the health probe")
 	flag.StringVar(&logEncoder, "logEncoder", "json", "log encoding ('json' or 'console')")
 	flag.StringVar(&logTimestampFormat, "log-timestamp-format", "millis", "log timestamp format ('millis', 'nanos', 'epoch', 'rfc3339' or 'rfc3339nano')")
-	flag.IntVar(&syncPeriodSeconds, "syncPeriodSeconds", 60*60, "The informers resync period in seconds") // default 1 hour
+	flag.IntVar(&syncPeriodSeconds, "syncPeriodSeconds", 60*60, "The informers resync period in seconds")                                            // default 1 hour
+	flag.DurationVar(&clientTimeoutDuration, "client-timeout", 0, "The maximum length of time to wait before giving up on a kube-apiserver request") // is set to 0, keep default
 	flag.StringVar(&leaderElectionResourceLock, "leader-election-resource", "configmaps", "determines which resource lock to use for leader election. option:[configmapsleases|endpointsleases|configmaps]")
 	flag.BoolVar(&ddProfilingEnabled, "ddProfilingEnabled", false, "Enable the datadog profiler")
 	flag.IntVar(&workers, "workers", 1, "Maximum number of concurrent Reconciles which can be run")
@@ -106,6 +108,10 @@ func main() {
 	syncDuration := time.Duration(syncPeriodSeconds) * time.Second
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.UserAgent = "wpa-controller"
+	if clientTimeoutDuration != 0 {
+		// override client timeout duration if set
+		restConfig.Timeout = clientTimeoutDuration
+	}
 	mgr, err := ctrl.NewManager(restConfig, config.ManagerOptionsWithNamespaces(setupLog, ctrl.Options{
 		Scheme:                     scheme,
 		MetricsBindAddress:         fmt.Sprintf("%s:%d", host, metricsPort),


### PR DESCRIPTION
### What does this PR do?

Add a new wpa-controller parameter to set the duration of the kube-apiserver client timeout.

### Motivation

This parameter can be usefull in some environment when the api-server takes time to reply.
It should avoid having the controller in a bad shape.

### Additional Notes

N/A

### Describe your test plan

Not easy to test the impact of this new parameter with a working API-server. 
