### PR TITLE
Adding support for delayScale with multi metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ In the following example, we can see that the recommended number of replicas is 
 * **Scaling Delay**
 <a name="delay"></a>
 
-In order to avoid scaling from bursts you can use the following features: `downscaleDelayBelowWatermarkSeconds` and/or `upscaleDelayAboveWatermarkSeconds`. These options are specified as integers. The metric has to remain above or under its respective watermark for the configured duration.
+In order to avoid scaling from bursts you can use the following features: `downscaleDelayBelowWatermarkSeconds` and/or `upscaleDelayAboveWatermarkSeconds`. These options are specified as integers. The metric(s) have to remain above or under its/their respective watermark for the configured duration.
 You can keep track of how much time is left in the status of the WPA:
 
 ```
@@ -188,7 +188,9 @@ Or in the logs of the controller:
 {"level":"info","ts":1668481092517.446,"logger":"controllers.WatermarkPodAutoscaler","msg":"Will not scale: value has not been out of bounds for long enough","watermarkpodautoscaler":"datadog/example-watermarkpodautoscaler","wpa_name":"example-watermarkpodautoscaler","wpa_namespace":"datadog","time_left":3209}
 ```
 
-**Note:** This feauture does not support using multiple metrics. 
+**Note:** If you are using multiple metrics with this feature, the above/below condition is considered using the `OR` of the metrics.
+
+e.g. if you have a 60s upscaleDelay with 2 metrics (M1 and M2), M1 stays above it's high watermark for 40s `[t0; t40]` and the M2 one goes above it's high watermark for 30s while overlapping with M1 during it's last 10s: `[t30; t60]`, this will validate the upscaleDelay condition and allow for an upscaling event.
 
 * **Precedence**
 <a name="precedence"></a>
@@ -216,7 +218,7 @@ If all the conditions are met, the controller will scale the targeted object in 
 
 ## Limitations
 
-- Only officially supports one metric per WPA.
+- Only officially supports one metric per WPA: While the logic supports multiple metrics and will apply the greatest recommendation of all metrics, the status needs some refactoring to reflect this insight.
 - Does not take CPU into account to normalize the number of replicas.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Or in the logs of the controller:
 
 **Note:** If you are using multiple metrics with this feature, the above/below condition is considered using the `OR` of the metrics.
 
-e.g. if you have a 60s upscaleDelay with 2 metrics (M1 and M2), M1 stays above it's high watermark for 40s `[t0; t40]` and the M2 one goes above it's high watermark for 30s while overlapping with M1 during it's last 10s: `[t30; t60]`, this will validate the upscaleDelay condition and allow for an upscaling event.
+For example, suppose you have a 60 second `upscaleDelay` with two metrics, M1 and M2. If M1 stays above its high watermark for 40 seconds `[t0; t40]`, and the M2 one goes above its high watermark for 30 seconds, overlapping with M1 during its last 10 seconds, `[t30; t60]`, this validates the `upscaleDelay` condition and allows for an upscaling event.
 
 * **Precedence**
 <a name="precedence"></a>
@@ -218,7 +218,7 @@ If all the conditions are met, the controller will scale the targeted object in 
 
 ## Limitations
 
-- Only officially supports one metric per WPA: While the logic supports multiple metrics and will apply the greatest recommendation of all metrics, the status needs some refactoring to reflect this insight.
+- Only officially supports one metric per WPA. While the logic supports multiple metrics and applies the greatest recommendation of all metrics, the status needs some refactoring to reflect this insight.
 - Does not take CPU into account to normalize the number of replicas.
 
 ## Troubleshooting

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -38,6 +38,12 @@ type ReplicaCalculation struct {
 	utilization   int64
 	timestamp     time.Time
 	readyReplicas int32
+	pos           MetricPosition
+}
+
+type MetricPosition struct {
+	isAbove bool
+	isBelow bool
 }
 
 // ReplicaCalculatorItf interface for ReplicaCalculator
@@ -122,7 +128,7 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, target
 		labelsWithReason[reasonPromLabel] = withinBoundsPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
 		value.Delete(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: metricName})
-		return ReplicaCalculation{0, 0, time.Time{}, 0}, fmt.Errorf("unable to get external metric %s/%s/%+v: %s", wpa.Namespace, metricName, selector, err) //nolint:errorlint
+		return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, fmt.Errorf("unable to get external metric %s/%s/%+v: %s", wpa.Namespace, metricName, selector, err) //nolint:errorlint
 	}
 	logger.Info("Metrics from the External Metrics Provider", "metrics", metrics)
 
@@ -133,9 +139,9 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, target
 
 	// if the average algorithm is used, the metrics retrieved has to be divided by the number of available replicas.
 	adjustedUsage := float64(sum) / averaged
-	replicaCount, utilizationQuantity := getReplicaCount(logger, target.Status.Replicas, currentReadyReplicas, wpa, metricName, adjustedUsage, metric.External.LowWatermark, metric.External.HighWatermark)
+	replicaCount, utilizationQuantity, metricPos := getReplicaCount(logger, target.Status.Replicas, currentReadyReplicas, wpa, metricName, adjustedUsage, metric.External.LowWatermark, metric.External.HighWatermark)
 	logger.Info("External Metric replica calculation", "metricName", metricName, "replicaCount", replicaCount, "utilizationQuantity", utilizationQuantity, "timestamp", timestamp, "currentReadyReplicas", currentReadyReplicas)
-	return ReplicaCalculation{replicaCount, utilizationQuantity, timestamp, currentReadyReplicas}, nil
+	return ReplicaCalculation{replicaCount, utilizationQuantity, timestamp, currentReadyReplicas, metricPos}, nil
 }
 
 // GetResourceReplicas calculates the desired replica count based on a target resource utilization percentage
@@ -145,7 +151,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 	selector := metric.Resource.MetricSelector
 	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		return ReplicaCalculation{0, 0, time.Time{}, 0}, err
+		return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, err
 	}
 
 	namespace := wpa.Namespace
@@ -166,22 +172,22 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 		labelsWithReason[reasonPromLabel] = withinBoundsPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
 		value.Delete(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: string(resourceName)})
-		return ReplicaCalculation{0, 0, time.Time{}, 0}, fmt.Errorf("unable to get resource metric %s/%s/%+v: %s", wpa.Namespace, resourceName, selector, err) //nolint:errorlint
+		return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, fmt.Errorf("unable to get resource metric %s/%s/%+v: %s", wpa.Namespace, resourceName, selector, err) //nolint:errorlint
 	}
 	logger.Info("Metrics from the Resource Client", "metrics", metrics)
 
 	lbl, err := labels.Parse(target.Status.Selector)
 	if err != nil {
-		return ReplicaCalculation{0, 0, time.Time{}, 0}, fmt.Errorf("could not parse the labels of the target: %w", err)
+		return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, fmt.Errorf("could not parse the labels of the target: %w", err)
 	}
 
 	podList, err := c.podLister.Pods(namespace).List(lbl)
 	if err != nil {
-		return ReplicaCalculation{0, 0, time.Time{}, 0}, fmt.Errorf("unable to get pods while calculating replica count: %w", err)
+		return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, fmt.Errorf("unable to get pods while calculating replica count: %w", err)
 	}
 
 	if len(podList) == 0 {
-		return ReplicaCalculation{0, 0, time.Time{}, 0}, fmt.Errorf("no pods returned by selector while calculating replica count")
+		return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, fmt.Errorf("no pods returned by selector while calculating replica count")
 	}
 	readiness := time.Duration(wpa.Spec.ReadinessDelaySeconds) * time.Second
 	readyPods, ignoredPods := groupPods(logger, podList, target.Name, metrics, resourceName, readiness)
@@ -195,7 +201,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 
 	removeMetricsForPods(metrics, ignoredPods)
 	if len(metrics) == 0 {
-		return ReplicaCalculation{0, 0, time.Time{}, 0}, fmt.Errorf("did not receive metrics for any ready pods")
+		return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, fmt.Errorf("did not receive metrics for any ready pods")
 	}
 
 	averaged := 1.0
@@ -209,12 +215,12 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 	}
 	adjustedUsage := float64(sum) / averaged
 
-	replicaCount, utilizationQuantity := getReplicaCount(logger, target.Status.Replicas, int32(readyPodCount), wpa, string(resourceName), adjustedUsage, metric.Resource.LowWatermark, metric.Resource.HighWatermark)
+	replicaCount, utilizationQuantity, metricPos := getReplicaCount(logger, target.Status.Replicas, int32(readyPodCount), wpa, string(resourceName), adjustedUsage, metric.Resource.LowWatermark, metric.Resource.HighWatermark)
 	logger.Info("Resource Metric replica calculation", "metricName", metric.Resource.Name, "replicaCount", replicaCount, "utilizationQuantity", utilizationQuantity, "timestamp", timestamp, "currentReadyReplicas", int32(readyPodCount))
-	return ReplicaCalculation{replicaCount, utilizationQuantity, timestamp, int32(readyPodCount)}, nil
+	return ReplicaCalculation{replicaCount, utilizationQuantity, timestamp, int32(readyPodCount), metricPos}, nil
 }
 
-func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, name string, adjustedUsage float64, lowMark, highMark *resource.Quantity) (replicaCount int32, utilization int64) {
+func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, name string, adjustedUsage float64, lowMark, highMark *resource.Quantity) (replicaCount int32, utilization int64, position MetricPosition) {
 	utilizationQuantity := resource.NewMilliQuantity(int64(adjustedUsage), resource.DecimalSI)
 	adjustedHM := float64(highMark.MilliValue() + highMark.MilliValue()*wpa.Spec.Tolerance.MilliValue()/1000)
 	adjustedLM := float64(lowMark.MilliValue() - lowMark.MilliValue()*wpa.Spec.Tolerance.MilliValue()/1000)
@@ -235,9 +241,8 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 			logger.Info("Recommendation is lower than current number of replicas while attempting to upscale, aborting", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas)
 			replicaCount = currentReplicas
 		}
-
-		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark, corev1.ConditionTrue, aboveHighWatermarkReason, aboveHighWatermarkAllowedMessage)
-		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark, corev1.ConditionFalse, belowLowWatermarkReason, belowLowWatermarkAllowedMessage)
+		position.isAbove = true
+		position.isBelow = false
 
 	case adjustedUsage < adjustedLM:
 		replicaCount = int32(math.Floor(float64(currentReadyReplicas) * adjustedUsage / (float64(lowMark.MilliValue()))))
@@ -253,25 +258,23 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 			replicaCount = currentReplicas
 		}
 
-		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark, corev1.ConditionFalse, aboveHighWatermarkReason, aboveHighWatermarkAllowedMessage)
-		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark, corev1.ConditionTrue, belowLowWatermarkReason, belowLowWatermarkAllowedMessage)
+		position.isAbove = false
+		position.isBelow = true
 
 	default:
 		restrictedScaling.With(labelsWithReason).Set(1)
 		value.With(labelsWithMetricName).Set(adjustedUsage)
 		logger.Info("Within bounds of the watermarks", "value", utilizationQuantity.String(), "currentReadyReplicas", currentReadyReplicas, "tolerance (%)", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedLM", adjustedLM, "adjustedHM", adjustedHM, "adjustedUsage", adjustedUsage)
-
-		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark, corev1.ConditionFalse, aboveHighWatermarkReason, aboveHighWatermarkAllowedMessage)
-		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark, corev1.ConditionFalse, belowLowWatermarkReason, belowLowWatermarkAllowedMessage)
-
+		position.isAbove = false
+		position.isBelow = false
 		// returning the currentReplicas instead of the count of healthy ones to be consistent with the upstream behavior.
-		return currentReplicas, utilizationQuantity.MilliValue()
+		return currentReplicas, utilizationQuantity.MilliValue(), position
 	}
 
 	restrictedScaling.With(labelsWithReason).Set(0)
 	value.With(labelsWithMetricName).Set(adjustedUsage)
 
-	return replicaCount, utilizationQuantity.MilliValue()
+	return replicaCount, utilizationQuantity.MilliValue(), position
 }
 
 func (c *ReplicaCalculator) getReadyPodsCount(log logr.Logger, targetName string, podList []*corev1.Pod, readinessDelay time.Duration) (int32, int32, error) {

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -50,6 +50,7 @@ type replicaCalcTestCase struct {
 	expectedError    error
 	timestamp        time.Time
 	readyReplicas    int32
+	pos              MetricPosition
 
 	namespace string
 	metric    *metricInfo
@@ -285,6 +286,8 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	assert.Equal(t, tc.metric.expectedUtilization, replicaCalculation.utilization, "utilization should be as expected")
 	assert.True(t, tc.timestamp.Equal(replicaCalculation.timestamp), "timestamp should be as expected")
 	assert.Equal(t, tc.readyReplicas, replicaCalculation.readyReplicas, "ready replicas should be as expected")
+	assert.Equal(t, tc.pos.isAbove, replicaCalculation.pos.isAbove, "metric should be above the Watermark")
+	assert.Equal(t, tc.pos.isBelow, replicaCalculation.pos.isBelow, "metric should be below the Watermark")
 }
 
 func TestReplicaCalcDisjointResourcesMetrics(t *testing.T) {
@@ -346,7 +349,11 @@ func TestReplicaCalcAbsoluteScaleUp(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 21,
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -379,7 +386,10 @@ func TestScaleIntervalReplicaCalcAbsoluteScaleUp(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 25, // 21 should be computed, but we round it up to the nearest interval of 5.
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -412,7 +422,11 @@ func TestScaleIntervalReplicaCalcNoScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3, // Even though 3 is not divisible by our scaling interval, no scale up was required so we do nothing.
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -445,7 +459,11 @@ func TestReplicaCalcAbsoluteScaleDown(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 1,
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -478,7 +496,11 @@ func TestScaleIntervalReplicaCalcAbsoluteScaleDown(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 2, // Replica scaling interval is 2, so we can't scale down to 1 replica even though that is our min.
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -511,7 +533,11 @@ func TestReplicaCalcAbsoluteScaleDownLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 2,
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -544,7 +570,11 @@ func TestReplicaCalcAbsoluteScaleUpPendingLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 6,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				// With the absolute algorithm, we will have a utilization of 120k compared to a HWM of 48k (inc. tolerance)
@@ -581,7 +611,11 @@ func TestReplicaCalcAbsoluteScaleUpPendingLessScaleExtraReplica(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 7,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -615,7 +649,11 @@ func TestReplicaCalcAbsoluteScaleUpPendingNoScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    1,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -683,7 +721,11 @@ func TestReplicaCalcAbsoluteScaleUpFailedLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 6,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -717,7 +759,11 @@ func TestReplicaCalcAbsoluteScaleUpUnreadyLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 6,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -765,7 +811,11 @@ func TestReplicaCalcAverageScaleUp(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 7,
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -838,7 +888,11 @@ func TestReplicaCalcAverageScaleDown(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 1,
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -871,7 +925,11 @@ func TestReplicaCalcAverageScaleDownLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 2,
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -905,6 +963,10 @@ func TestReplicaCalcAverageScaleUpPendingLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		expectedReplicas: 3,
 		readyReplicas:    2,
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -938,7 +1000,11 @@ func TestReplicaCalcAverageScaleUpPendingNoScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    1,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -972,7 +1038,11 @@ func TestReplicaCalcAverageScaleUpPendingNoScaleStretchTolerance(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    1,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -1006,7 +1076,11 @@ func TestReplicaCalcAverageScaleUpFailedLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -1041,7 +1115,11 @@ func TestReplicaCalcAverageScaleUpUnreadyLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -1096,7 +1174,11 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale1(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 9,
 		readyReplicas:    4,
-		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1129,7 +1211,11 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale2(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 20,
 		readyReplicas:    9,
-		scale:            makeScale(testDeploymentName, 9, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 9, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1163,7 +1249,11 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale3(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 2,
 		readyReplicas:    20,
-		scale:            makeScale(testDeploymentName, 20, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 20, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1197,7 +1287,11 @@ func TestReplicaCalcWithinAbsoluteExternal(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 9,
 		readyReplicas:    9,
-		scale:            makeScale(testDeploymentName, 9, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 9, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1235,7 +1329,11 @@ func TestReplicaCalcBelowAverageExternal_Downscale1(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 4,
 		readyReplicas:    5,
-		scale:            makeScale(testDeploymentName, 5, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 5, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -1269,7 +1367,11 @@ func TestReplicaCalcBelowAverageExternal_Downscale2(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    4,
-		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -1303,7 +1405,11 @@ func TestReplicaCalcBelowAverageExternal_Downscale3(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",
@@ -1337,7 +1443,11 @@ func TestPendingtExpiredScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 1,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1365,6 +1475,7 @@ func TestTooManyUnreadyPods(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 4,
 		readyReplicas:    1,
+		pos:              MetricPosition{},
 		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
@@ -1402,7 +1513,11 @@ func TestPendingNotExpiredScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 1,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: true,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1440,7 +1555,7 @@ func TestPendingNotExpiredScale(t *testing.T) {
 	tc.runTest(t)
 }
 
-// We have pods that are expired and only one is above the HWM so we keep the number of replicas.
+// We have pods that are expired and only one is above the HWM so we keep the number of replicas since not enough pods are ready.
 func TestPendingExpiredHigherWatermarkDownscale(t *testing.T) {
 	logf.SetLogger(zap.New())
 
@@ -1459,7 +1574,11 @@ func TestPendingExpiredHigherWatermarkDownscale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    1,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1490,7 +1609,7 @@ func TestPendingExpiredHigherWatermarkDownscale(t *testing.T) {
 		podStartTime: []metav1.Time{startTime, startTime, startTime},
 		metric: &metricInfo{
 			spec:                metric1,
-			levels:              []int64{90000}, // We are within the watermarks
+			levels:              []int64{90000}, // We are higher than the high watermark
 			expectedUtilization: 90000,
 		},
 	}
@@ -1517,7 +1636,11 @@ func TestPendingNotExpiredWithinBoundsNoScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: false,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1574,7 +1697,11 @@ func TestPendingNotOverlyScaling(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 19,
 		readyReplicas:    2,
-		scale:            makeScale(testDeploymentName, 7, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 7, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "absolute",
@@ -1648,7 +1775,11 @@ func TestPendingUnprotectedOverlyScaling(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 66,
 		readyReplicas:    7,
-		scale:            makeScale(testDeploymentName, 7, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 7, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm: "absolute",
@@ -1719,7 +1850,11 @@ func TestReplicaCalcBelowAverageExternal_Downscale4(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 5,
 		readyReplicas:    3,
-		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		pos: MetricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
 				Algorithm:                    "average",

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -50,7 +50,7 @@ type replicaCalcTestCase struct {
 	expectedError    error
 	timestamp        time.Time
 	readyReplicas    int32
-	pos              MetricPosition
+	pos              metricPosition
 
 	namespace string
 	metric    *metricInfo
@@ -349,7 +349,7 @@ func TestReplicaCalcAbsoluteScaleUp(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 21,
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -386,8 +386,9 @@ func TestScaleIntervalReplicaCalcAbsoluteScaleUp(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 25, // 21 should be computed, but we round it up to the nearest interval of 5.
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
+			isBelow: false,
 		},
 		scale: makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
@@ -422,7 +423,7 @@ func TestScaleIntervalReplicaCalcNoScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3, // Even though 3 is not divisible by our scaling interval, no scale up was required so we do nothing.
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: false,
 		},
@@ -459,7 +460,7 @@ func TestReplicaCalcAbsoluteScaleDown(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 1,
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -496,7 +497,7 @@ func TestScaleIntervalReplicaCalcAbsoluteScaleDown(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 2, // Replica scaling interval is 2, so we can't scale down to 1 replica even though that is our min.
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -533,7 +534,7 @@ func TestReplicaCalcAbsoluteScaleDownLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 2,
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -570,7 +571,7 @@ func TestReplicaCalcAbsoluteScaleUpPendingLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 6,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -611,7 +612,7 @@ func TestReplicaCalcAbsoluteScaleUpPendingLessScaleExtraReplica(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 7,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -649,7 +650,7 @@ func TestReplicaCalcAbsoluteScaleUpPendingNoScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    1,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: false,
 		},
@@ -721,7 +722,7 @@ func TestReplicaCalcAbsoluteScaleUpFailedLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 6,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -759,7 +760,7 @@ func TestReplicaCalcAbsoluteScaleUpUnreadyLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 6,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -811,7 +812,7 @@ func TestReplicaCalcAverageScaleUp(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 7,
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -888,7 +889,7 @@ func TestReplicaCalcAverageScaleDown(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 1,
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -925,7 +926,7 @@ func TestReplicaCalcAverageScaleDownLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 2,
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -963,7 +964,7 @@ func TestReplicaCalcAverageScaleUpPendingLessScale(t *testing.T) {
 		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
 		expectedReplicas: 3,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1000,7 +1001,7 @@ func TestReplicaCalcAverageScaleUpPendingNoScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    1,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: false,
 		},
@@ -1038,7 +1039,7 @@ func TestReplicaCalcAverageScaleUpPendingNoScaleStretchTolerance(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    1,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1076,7 +1077,7 @@ func TestReplicaCalcAverageScaleUpFailedLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1115,7 +1116,7 @@ func TestReplicaCalcAverageScaleUpUnreadyLessScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1174,7 +1175,7 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale1(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 9,
 		readyReplicas:    4,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1211,7 +1212,7 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale2(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 20,
 		readyReplicas:    9,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1249,7 +1250,7 @@ func TestReplicaCalcAboveAbsoluteExternal_Upscale3(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 2,
 		readyReplicas:    20,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -1287,7 +1288,7 @@ func TestReplicaCalcWithinAbsoluteExternal(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 9,
 		readyReplicas:    9,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: false,
 		},
@@ -1329,7 +1330,7 @@ func TestReplicaCalcBelowAverageExternal_Downscale1(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 4,
 		readyReplicas:    5,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -1367,7 +1368,7 @@ func TestReplicaCalcBelowAverageExternal_Downscale2(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    4,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -1405,7 +1406,7 @@ func TestReplicaCalcBelowAverageExternal_Downscale3(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: false,
 		},
@@ -1443,7 +1444,7 @@ func TestPendingtExpiredScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 1,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -1475,7 +1476,7 @@ func TestTooManyUnreadyPods(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 4,
 		readyReplicas:    1,
-		pos:              MetricPosition{},
+		pos:              metricPosition{},
 		scale:            makeScale(testDeploymentName, 4, map[string]string{"name": "test-pod"}),
 		wpa: &v1alpha1.WatermarkPodAutoscaler{
 			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
@@ -1513,7 +1514,7 @@ func TestPendingNotExpiredScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 1,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: true,
 		},
@@ -1574,7 +1575,7 @@ func TestPendingExpiredHigherWatermarkDownscale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    1,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1636,7 +1637,7 @@ func TestPendingNotExpiredWithinBoundsNoScale(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 3,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: false,
 			isBelow: false,
 		},
@@ -1697,7 +1698,7 @@ func TestPendingNotOverlyScaling(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 19,
 		readyReplicas:    2,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1775,7 +1776,7 @@ func TestPendingUnprotectedOverlyScaling(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 66,
 		readyReplicas:    7,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},
@@ -1850,7 +1851,7 @@ func TestReplicaCalcBelowAverageExternal_Downscale4(t *testing.T) {
 	tc := replicaCalcTestCase{
 		expectedReplicas: 5,
 		readyReplicas:    3,
-		pos: MetricPosition{
+		pos: metricPosition{
 			isAbove: true,
 			isBelow: false,
 		},

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -559,7 +559,7 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasForMetrics(logger logr
 				timestampProposal = replicaCalculation.timestamp
 				readyReplicasProposal = replicaCalculation.readyReplicas
 				// If multiple metrics are used, we keep track of whether at least one of them is outside of the bounds.
-				// This is later used for the delayScaling feature, which only supports OR for now.
+				// This is later used for the delayScaling feature, which only supports `OR` for now.
 				isAbove = isAbove || replicaCalculation.pos.isAbove
 				isBelow = isBelow || replicaCalculation.pos.isBelow
 

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -59,6 +59,8 @@ const (
 
 	defaultRequeueDelay       = time.Second
 	scaleNotFoundRequeueDelay = 10 * time.Second
+
+	desiredCountAcceptable = "the desired count is within the acceptable range"
 )
 
 // WatermarkPodAutoscalerReconciler reconciles a WatermarkPodAutoscaler object
@@ -471,7 +473,8 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasForMetrics(logger logr
 	}
 	replicaMin.With(labels).Set(minReplicas)
 	replicaMax.With(labels).Set(float64(wpa.Spec.MaxReplicas))
-
+	var isAbove bool
+	var isBelow bool
 	for i, metricSpec := range wpa.Spec.Metrics {
 		if metricSpec.External == nil && metricSpec.Resource == nil {
 			continue
@@ -507,6 +510,10 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasForMetrics(logger logr
 				utilizationProposal = replicaCalculation.utilization
 				timestampProposal = replicaCalculation.timestamp
 				readyReplicasProposal = replicaCalculation.readyReplicas
+				// If multiple metrics are used, we keep track of whether at least one of them is outside of the bounds.
+				// This is later used for the delayScaling feature, which only supports `OR` for now.
+				isAbove = isAbove || replicaCalculation.pos.isAbove
+				isBelow = isBelow || replicaCalculation.pos.isBelow
 
 				lowwm.With(promLabelsForWpaWithMetricName).Set(float64(metricSpec.External.LowWatermark.MilliValue()))
 				lowwmV2.With(promLabelsForWpaWithMetricName).Set(float64(metricSpec.External.LowWatermark.MilliValue()))
@@ -551,6 +558,10 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasForMetrics(logger logr
 				utilizationProposal = replicaCalculation.utilization
 				timestampProposal = replicaCalculation.timestamp
 				readyReplicasProposal = replicaCalculation.readyReplicas
+				// If multiple metrics are used, we keep track of whether at least one of them is outside of the bounds.
+				// This is later used for the delayScaling feature, which only supports OR for now.
+				isAbove = isAbove || replicaCalculation.pos.isAbove
+				isBelow = isBelow || replicaCalculation.pos.isBelow
 
 				lowwm.With(promLabelsForWpaWithMetricName).Set(float64(metricSpec.Resource.LowWatermark.MilliValue()))
 				lowwmV2.With(promLabelsForWpaWithMetricName).Set(float64(metricSpec.Resource.LowWatermark.MilliValue()))
@@ -583,6 +594,17 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasForMetrics(logger logr
 			readyReplicas = readyReplicasProposal
 		}
 	}
+	condAbove := corev1.ConditionFalse
+	if isAbove {
+		condAbove = corev1.ConditionTrue
+	}
+	condBelow := corev1.ConditionFalse
+	if isBelow {
+		condBelow = corev1.ConditionTrue
+	}
+
+	setCondition(wpa, datadoghqv1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark, condAbove, aboveHighWatermarkReason, aboveHighWatermarkAllowedMessage)
+	setCondition(wpa, datadoghqv1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark, condBelow, belowLowWatermarkReason, belowLowWatermarkAllowedMessage)
 	setCondition(wpa, autoscalingv2.ScalingActive, corev1.ConditionTrue, datadoghqv1alpha1.ConditionValidMetricFound, "the WPA was able to successfully calculate a replica count from %s", metric)
 
 	return replicas, metric, statuses, timestamp, readyReplicas, nil
@@ -731,7 +753,7 @@ func convertDesiredReplicasWithRules(logger logr.Logger, wpa *datadoghqv1alpha1.
 	}
 
 	possibleLimitingCondition = "DesiredWithinRange"
-	possibleLimitingReason = "the desired count is within the acceptable range"
+	possibleLimitingReason = desiredCountAcceptable
 
 	return desiredReplicas, possibleLimitingCondition, possibleLimitingReason
 }

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -498,7 +498,7 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 				replicaCalculatorFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 					// With 3 replicas, we simulate wanting to have 8 replicas
 					// The metric's ts is old, using it as a reference would make it seem like LastScaleTime is in the future.
-					return ReplicaCalculation{8, 20, time.Now().Add(-60 * time.Second), 3, MetricPosition{true, false}}, nil
+					return ReplicaCalculation{8, 20, time.Now().Add(-60 * time.Second), 3, metricPosition{true, false}}, nil
 				},
 				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
 					Labels: map[string]string{"foo-key": "bar-value"},
@@ -589,7 +589,7 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 			args: args{
 				replicaCalculatorFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 					// utilization is low enough to warrant downscaling to 1 replica
-					return ReplicaCalculation{1, 20, time.Now().Add(-60 * time.Second), 3, MetricPosition{false, true}}, nil
+					return ReplicaCalculation{1, 20, time.Now().Add(-60 * time.Second), 3, metricPosition{false, true}}, nil
 				},
 				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
 					Labels: map[string]string{"foo-key": "bar-value"},
@@ -677,7 +677,7 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 			args: args{
 				replicaCalculatorFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 					// utilization is high enough to warrant upscaling to 5 replica
-					return ReplicaCalculation{5, 130, time.Now(), 3, MetricPosition{true, false}}, nil
+					return ReplicaCalculation{5, 130, time.Now(), 3, metricPosition{true, false}}, nil
 				},
 				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
 					Labels: map[string]string{"foo-key": "bar-value"},
@@ -775,7 +775,7 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 			args: args{
 				replicaCalculatorFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 					// utilization is high enough to warrant upscaling to 5 replica
-					return ReplicaCalculation{5, 35, time.Now().Add(-60 * time.Second), 8, MetricPosition{false, true}}, nil
+					return ReplicaCalculation{5, 35, time.Now().Add(-60 * time.Second), 8, metricPosition{false, true}}, nil
 				},
 				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
 					Labels: map[string]string{"foo-key": "bar-value"},
@@ -973,7 +973,7 @@ func TestReconcileWatermarkPodAutoscaler_computeReplicasForMetrics(t *testing.T)
 			},
 			wantFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 				// With 8 replicas, the avg algo and an external value returned of 100 we have 10 replicas and the utilization of 10
-				return ReplicaCalculation{10, 10, time.Time{}, 8, MetricPosition{true, false}}, nil
+				return ReplicaCalculation{10, 10, time.Time{}, 8, metricPosition{true, false}}, nil
 			},
 			err: nil,
 		},
@@ -1006,7 +1006,7 @@ func TestReconcileWatermarkPodAutoscaler_computeReplicasForMetrics(t *testing.T)
 			},
 			wantFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 				// With 8 replicas, the avg algo and an external value returned of 100 we have 10 replicas and the utilization of 10
-				return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, fmt.Errorf("unable to fetch metrics from external metrics API")
+				return ReplicaCalculation{0, 0, time.Time{}, 0, metricPosition{}}, fmt.Errorf("unable to fetch metrics from external metrics API")
 			},
 			err: fmt.Errorf("failed to compute replicas based on external metric deadbeef: unable to fetch metrics from external metrics API"),
 		},
@@ -1052,9 +1052,9 @@ func TestReconcileWatermarkPodAutoscaler_computeReplicasForMetrics(t *testing.T)
 			wantFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 				// With 8 replicas, the avg algo and an external value returned of 100 we have 10 replicas and the utilization of 10
 				if metric.External.MetricName == "deadbeef" {
-					return ReplicaCalculation{10, 10, time.Time{}, 8, MetricPosition{true, false}}, nil
+					return ReplicaCalculation{10, 10, time.Time{}, 8, metricPosition{true, false}}, nil
 				}
-				return ReplicaCalculation{8, 5, time.Time{}, 8, MetricPosition{false, false}}, nil
+				return ReplicaCalculation{8, 5, time.Time{}, 8, metricPosition{false, false}}, nil
 			},
 			err: nil,
 		},
@@ -1095,14 +1095,14 @@ func (f *fakeReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, ta
 	if f.replicasFunc != nil {
 		return f.replicasFunc(metric, wpa)
 	}
-	return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, nil
+	return ReplicaCalculation{0, 0, time.Time{}, 0, metricPosition{}}, nil
 }
 
 func (f *fakeReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *autoscalingv1.Scale, metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 	if f.replicasFunc != nil {
 		return f.replicasFunc(metric, wpa)
 	}
-	return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, nil
+	return ReplicaCalculation{0, 0, time.Time{}, 0, metricPosition{}}, nil
 }
 
 func TestDefaultWatermarkPodAutoscaler(t *testing.T) {

--- a/controllers/watermarkpodautoscaler_controller_test.go
+++ b/controllers/watermarkpodautoscaler_controller_test.go
@@ -498,7 +498,7 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 				replicaCalculatorFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 					// With 3 replicas, we simulate wanting to have 8 replicas
 					// The metric's ts is old, using it as a reference would make it seem like LastScaleTime is in the future.
-					return ReplicaCalculation{8, 20, time.Now().Add(-60 * time.Second), 3}, nil
+					return ReplicaCalculation{8, 20, time.Now().Add(-60 * time.Second), 3, MetricPosition{true, false}}, nil
 				},
 				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
 					Labels: map[string]string{"foo-key": "bar-value"},
@@ -508,6 +508,11 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 							{
 								Type:               v1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark,
 								Status:             corev1.ConditionTrue,
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
+							},
+							{
+								Type:               v1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark,
+								Status:             corev1.ConditionFalse,
 								LastTransitionTime: metav1.Time{Time: time.Now().Add(-30 * time.Second)},
 							},
 						},
@@ -545,7 +550,7 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 				if wpa.Status.DesiredReplicas != desired {
 					return fmt.Errorf(fmt.Sprintf("incorrect amount of desired replicas. Expected %d - has %d", desired, wpa.Status.DesiredReplicas))
 				}
-				if len(wpa.Status.Conditions) != 5 {
+				if len(wpa.Status.Conditions) != 6 {
 					return fmt.Errorf("incomplete reconciliation process, missing conditions")
 				}
 				for _, c := range wpa.Status.Conditions {
@@ -584,7 +589,7 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 			args: args{
 				replicaCalculatorFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 					// utilization is low enough to warrant downscaling to 1 replica
-					return ReplicaCalculation{1, 20, time.Now().Add(-60 * time.Second), 3}, nil
+					return ReplicaCalculation{1, 20, time.Now().Add(-60 * time.Second), 3, MetricPosition{false, true}}, nil
 				},
 				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
 					Labels: map[string]string{"foo-key": "bar-value"},
@@ -672,17 +677,17 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 			args: args{
 				replicaCalculatorFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 					// utilization is high enough to warrant upscaling to 5 replica
-					return ReplicaCalculation{5, 130, time.Now().Add(-60 * time.Second), 3}, nil
+					return ReplicaCalculation{5, 130, time.Now(), 3, MetricPosition{true, false}}, nil
 				},
 				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
 					Labels: map[string]string{"foo-key": "bar-value"},
 					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
-						LastScaleTime: &metav1.Time{Time: time.Now().Add(-90 * time.Second)},
+						LastScaleTime: &metav1.Time{Time: time.Now().Add(-45 * time.Second)},
 						Conditions: []v2beta1.HorizontalPodAutoscalerCondition{
 							{
 								Type:               v1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark,
-								Status:             corev1.ConditionFalse, // last evaluated metric is not out of bounds
-								LastTransitionTime: metav1.Time{Time: time.Now().Add(-3600 * time.Second)},
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: metav1.Time{Time: time.Now()}, // the metric just went above the HW.
 							},
 							{
 								Type:               v1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark,
@@ -695,8 +700,8 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 						ScaleTargetRef:                      testCrossVersionObjectRef,
 						MaxReplicas:                         5,
 						ScaleUpLimitFactor:                  resource.NewQuantity(150, resource.DecimalSI),
-						UpscaleForbiddenWindowSeconds:       30,
-						DownscaleForbiddenWindowSeconds:     45,
+						UpscaleForbiddenWindowSeconds:       30, // we are allowed to upscale since we last scaled 45s ago.
+						DownscaleForbiddenWindowSeconds:     60,
 						UpscaleDelayAboveWatermarkSeconds:   0, // feature is disabled, not blocking multi metric yielding an upscale
 						DownscaleDelayBelowWatermarkSeconds: 60,
 						MinReplicas:                         getReplicas(1),
@@ -748,6 +753,113 @@ func TestReconcileWatermarkPodAutoscaler_reconcileWPA(t *testing.T) {
 						}
 						if c.Message != "the WPA controller was able to update the target scale to 5" {
 							return fmt.Errorf("did not scale as expected")
+						}
+					case v2beta1.ScalingLimited:
+						if c.Message != "the desired count is within the acceptable range" {
+							return fmt.Errorf("scaling incorrectly throttled")
+						}
+					}
+				}
+				return nil
+			},
+		},
+		{
+			name: "Multi metric support with delaying downscale with only one metric downscaling",
+			fields: fields{
+				client:        fake.NewClientBuilder().Build(),
+				scaleclient:   &fakescale.FakeScaleClient{},
+				restmapper:    testrestmapper.TestOnlyStaticRESTMapper(s),
+				scheme:        s,
+				eventRecorder: eventRecorder,
+			},
+			args: args{
+				replicaCalculatorFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
+					// utilization is high enough to warrant upscaling to 5 replica
+					return ReplicaCalculation{5, 35, time.Now().Add(-60 * time.Second), 8, MetricPosition{false, true}}, nil
+				},
+				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
+					Labels: map[string]string{"foo-key": "bar-value"},
+					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
+						LastScaleTime: &metav1.Time{Time: time.Now().Add(-90 * time.Second)},
+						Conditions: []v2beta1.HorizontalPodAutoscalerCondition{
+							{
+								Type:               v1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark,
+								Status:             corev1.ConditionFalse, // last evaluated metric is not out of bounds
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(-3600 * time.Second)},
+							},
+							{
+								Type:               v1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark,
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(-61 * time.Second)},
+							},
+						},
+					},
+					Spec: &v1alpha1.WatermarkPodAutoscalerSpec{
+						ScaleTargetRef:                      testCrossVersionObjectRef,
+						MaxReplicas:                         10,
+						ScaleUpLimitFactor:                  resource.NewQuantity(150, resource.DecimalSI),
+						ScaleDownLimitFactor:                resource.NewQuantity(50, resource.DecimalSI),
+						UpscaleForbiddenWindowSeconds:       30,
+						DownscaleForbiddenWindowSeconds:     45, // the last scaling event is past the forbidden window.
+						UpscaleDelayAboveWatermarkSeconds:   0,  // feature is disabled, not blocking multi metric yielding an upscale.
+						DownscaleDelayBelowWatermarkSeconds: 60, // we have been below the watermark for more than the config.
+						MinReplicas:                         getReplicas(1),
+						Metrics: []v1alpha1.MetricSpec{
+							{
+								Type: v1alpha1.ExternalMetricSourceType,
+								External: &v1alpha1.ExternalMetricSource{
+									MetricName:     "deadbeef-yield-downscale",
+									MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value1"}},
+									HighWatermark:  resource.NewMilliQuantity(80, resource.DecimalSI),
+									LowWatermark:   resource.NewMilliQuantity(70, resource.DecimalSI),
+								},
+							},
+							{
+								Type: v1alpha1.ExternalMetricSourceType,
+								External: &v1alpha1.ExternalMetricSource{
+									MetricName:     "deadbeef-within-bounds",
+									MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"label": "value2"}},
+									HighWatermark:  resource.NewMilliQuantity(150, resource.DecimalSI),
+									LowWatermark:   resource.NewMilliQuantity(120, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				}),
+				wantReplicasCount: 5,
+				scale:             newScaleForDeployment(8),
+				loadFunc: func(c client.Client, wpa *v1alpha1.WatermarkPodAutoscaler) {
+					wpa = v1alpha1.DefaultWatermarkPodAutoscaler(wpa)
+					wpa.Spec.ScaleTargetRef = testCrossVersionObjectRef
+					_ = c.Create(context.TODO(), wpa)
+				},
+			},
+			wantErr: false,
+			wantFunc: func(c client.Client, desired int32, wpa *v1alpha1.WatermarkPodAutoscaler) error {
+				if wpa.Status.DesiredReplicas != desired {
+					return fmt.Errorf(fmt.Sprintf("incorrect amount of desired replicas. Expected %d - has %d", desired, wpa.Status.DesiredReplicas))
+				}
+				if len(wpa.Status.Conditions) != 6 {
+					return fmt.Errorf("incomplete reconciliation process, missing conditions")
+				}
+				t.Logf("%#v", wpa.Status.Conditions)
+				for _, c := range wpa.Status.Conditions {
+					switch c.Type {
+					case v2beta1.AbleToScale:
+						if c.Status != corev1.ConditionTrue {
+							// TODO we need more granularity on this condition to reflect that we are in not allowed to downscale.
+							return fmt.Errorf("should be able to scale")
+						}
+						if c.Message != "the WPA controller was able to update the target scale to 5" {
+							return fmt.Errorf("did not scale as expected")
+						}
+					case v1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark:
+						if c.Status != corev1.ConditionTrue {
+							return fmt.Errorf("scaling incorrectly blocked")
+						}
+					case v1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark:
+						if c.Status != corev1.ConditionFalse {
+							return fmt.Errorf("scaling incorrectly blocked")
 						}
 					case v2beta1.ScalingLimited:
 						if c.Message != "the desired count is within the acceptable range" {
@@ -861,7 +973,7 @@ func TestReconcileWatermarkPodAutoscaler_computeReplicasForMetrics(t *testing.T)
 			},
 			wantFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 				// With 8 replicas, the avg algo and an external value returned of 100 we have 10 replicas and the utilization of 10
-				return ReplicaCalculation{10, 10, time.Time{}, 8}, nil
+				return ReplicaCalculation{10, 10, time.Time{}, 8, MetricPosition{true, false}}, nil
 			},
 			err: nil,
 		},
@@ -894,7 +1006,7 @@ func TestReconcileWatermarkPodAutoscaler_computeReplicasForMetrics(t *testing.T)
 			},
 			wantFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 				// With 8 replicas, the avg algo and an external value returned of 100 we have 10 replicas and the utilization of 10
-				return ReplicaCalculation{0, 0, time.Time{}, 0}, fmt.Errorf("unable to fetch metrics from external metrics API")
+				return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, fmt.Errorf("unable to fetch metrics from external metrics API")
 			},
 			err: fmt.Errorf("failed to compute replicas based on external metric deadbeef: unable to fetch metrics from external metrics API"),
 		},
@@ -940,9 +1052,9 @@ func TestReconcileWatermarkPodAutoscaler_computeReplicasForMetrics(t *testing.T)
 			wantFunc: func(metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 				// With 8 replicas, the avg algo and an external value returned of 100 we have 10 replicas and the utilization of 10
 				if metric.External.MetricName == "deadbeef" {
-					return ReplicaCalculation{10, 10, time.Time{}, 8}, nil
+					return ReplicaCalculation{10, 10, time.Time{}, 8, MetricPosition{true, false}}, nil
 				}
-				return ReplicaCalculation{8, 5, time.Time{}, 8}, nil
+				return ReplicaCalculation{8, 5, time.Time{}, 8, MetricPosition{false, false}}, nil
 			},
 			err: nil,
 		},
@@ -983,14 +1095,14 @@ func (f *fakeReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, ta
 	if f.replicasFunc != nil {
 		return f.replicasFunc(metric, wpa)
 	}
-	return ReplicaCalculation{0, 0, time.Time{}, 0}, nil
+	return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, nil
 }
 
 func (f *fakeReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *autoscalingv1.Scale, metric v1alpha1.MetricSpec, wpa *v1alpha1.WatermarkPodAutoscaler) (replicaCalculation ReplicaCalculation, err error) {
 	if f.replicasFunc != nil {
 		return f.replicasFunc(metric, wpa)
 	}
-	return ReplicaCalculation{0, 0, time.Time{}, 0}, nil
+	return ReplicaCalculation{0, 0, time.Time{}, 0, MetricPosition{}}, nil
 }
 
 func TestDefaultWatermarkPodAutoscaler(t *testing.T) {
@@ -1487,7 +1599,7 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 		{
 			name:                      "wpaMinReplicas < scaleDownLimit < desiredReplicas",
 			possibleLimitingCondition: "DesiredWithinRange",
-			possibleLimitingReason:    "the desired count is within the acceptable range",
+			possibleLimitingReason:    desiredCountAcceptable,
 			desiredReplicas:           40,
 			currentReplicas:           50,
 			normalizedReplicas:        40,
@@ -1517,7 +1629,7 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 		{
 			name:                      "desiredReplicas < wpaMaxReplicas < scaleUpLimit",
 			possibleLimitingCondition: "DesiredWithinRange",
-			possibleLimitingReason:    "the desired count is within the acceptable range",
+			possibleLimitingReason:    desiredCountAcceptable,
 			desiredReplicas:           55,
 			currentReplicas:           50,
 			normalizedReplicas:        55,


### PR DESCRIPTION
### What does this PR do?

The current feature to delay scaling decision only supports one metric.
This introduces the logic necessary to support multiple metrics.
Note that for now the logic will use `OR`, so not all the metrics need to be beyond their watermarks for the duration of the delay. Further, if the union of the metrics's time beyond their respective watermarks goes longer than the configured delay, this will also allow for a scaling event to occur.

We would consider using `AND` in order to only scale if *all* metrics are beyond their respective watermarks, but it'd require a larger change with refactoring of the Status to report all the metrics's positions.

### Motivation

Feature Request

### Additional Notes

The best way to monitor this is by using the log: `Will not scale: value has not been out of bounds for long enough` that has the `time_left` as an argument. 
Alternatively, you can check the conditions of your WPA for `AbleToScale` with status `ReadyForScale` set to `True` (unless in Dry-Run).
