### PR TITLE
Converging toward any watermark 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ vendor
 # Temporary Build Files
 build/_output
 build/_test
+controllers/__debug_bin
+errors
 cmd/kubectl-wpa/kubectl-wpa
 # Vendor folder
 /controller

--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -49,6 +49,16 @@ type CrossVersionObjectReference struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 }
 
+// ConvergeTowardsWatermarkType indicates the direction to converge to while in stable regime (when the value is between watermarks).
+type ConvergeTowardsWatermarkType string
+
+var (
+	// ConvergeUpwards will suggest downscaling the target for a value to converge towards it's High Watermark.
+	ConvergeUpwards ConvergeTowardsWatermarkType = "highwatermark"
+	// ConvergeUpwards will suggest upscaling the target for a value to converge towards it's Low Watermark.
+	ConvergeDownwards ConvergeTowardsWatermarkType = "lowwatermark"
+)
+
 // WatermarkPodAutoscalerSpec defines the desired state of WatermarkPodAutoscaler
 // +k8s:openapi-gen=true
 type WatermarkPodAutoscalerSpec struct {
@@ -79,6 +89,10 @@ type WatermarkPodAutoscalerSpec struct {
 	// Allows for special scaling patterns, for instance when an application requires a certain number of pods in multiple
 	// +kubebuilder:validation:Minimum=1
 	ReplicaScalingAbsoluteModulo *int32 `json:"replicaScalingAbsoluteModulo,omitempty"`
+
+	// Try to make the usage converge towards High Watermark to save resources. This will slowly downscale by `ReplicaScalingAbsoluteModulo`
+	// if the predicted usage stays bellow the high watermarks.
+	ConvergeTowardsWatermark ConvergeTowardsWatermarkType `json:"convergeTowardsWatermark,omitempty"`
 
 	// Parameter used to be a float, in order to support the transition seamlessly, we validate that it is ]0;1[ in the code.
 	Tolerance resource.Quantity `json:"tolerance,omitempty"`
@@ -220,6 +234,9 @@ const WatermarkPodAutoscalerStatusBelowLowWatermark autoscalingv2.HorizontalPodA
 
 // WatermarkPodAutoscalerStatusAboveHighWatermark ConditionType used when the value is above the high watermark
 const WatermarkPodAutoscalerStatusAboveHighWatermark autoscalingv2.HorizontalPodAutoscalerConditionType = "AboveHighWatermark"
+
+// WatermarkPodAutoscalerStatusConvergeToWatermark ConditionType used when the value is within bound and we're trying to converge to the one of the watermarks
+const WatermarkPodAutoscalerStatusConvergeToWatermark autoscalingv2.HorizontalPodAutoscalerConditionType = "ConvergeToWatermark"
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -280,6 +280,13 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerSpec(ref common.ReferenceCallbac
 							Format:      "int32",
 						},
 					},
+					"convergeTowardsWatermark": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Try to make the usage converge towards High Watermark to save resources. This will slowly downscale by `ReplicaScalingAbsoluteModulo` if the predicted usage stays bellow the high watermarks.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"tolerance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameter used to be a float, in order to support the transition seamlessly, we validate that it is ]0;1[ in the code.",

--- a/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -76,6 +76,11 @@ spec:
               algorithm:
                 description: 'computed values take the # of replicas into account'
                 type: string
+              convergeTowardsWatermark:
+                description: Try to make the usage converge towards High Watermark
+                  to save resources. This will slowly downscale by `ReplicaScalingAbsoluteModulo`
+                  if the predicted usage stays bellow the high watermarks.
+                type: string
               downscaleDelayBelowWatermarkSeconds:
                 format: int32
                 minimum: 0

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -74,6 +74,11 @@ spec:
             algorithm:
               description: 'computed values take the # of replicas into account'
               type: string
+            convergeTowardsWatermark:
+              description: Try to make the usage converge towards High Watermark to
+                save resources. This will slowly downscale by `ReplicaScalingAbsoluteModulo`
+                if the predicted usage stays bellow the high watermarks.
+              type: string
             downscaleDelayBelowWatermarkSeconds:
               format: int32
               minimum: 0

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -231,7 +231,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 func getReplicaCountUpscale(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, adjustedUsage float64, highMark *resource.Quantity) (replicaCount int32) {
 	replicaCount = math32.Ceil(float64(currentReadyReplicas) * adjustedUsage / (float64(highMark.MilliValue())))
 	// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingAbsoluteModulo.
-	if replicaScalingAbsoluteModuloRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingAbsoluteModulo))); replicaScalingAbsoluteModuloRemainder > 0 {
+	if replicaScalingAbsoluteModuloRemainder := math32.Mod(replicaCount, *wpa.Spec.ReplicaScalingAbsoluteModulo); replicaScalingAbsoluteModuloRemainder > 0 {
 		replicaCount += *wpa.Spec.ReplicaScalingAbsoluteModulo - replicaScalingAbsoluteModuloRemainder
 	}
 

--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
+	"github.com/DataDog/watermarkpodautoscaler/pkg/math32"
 
 	metricsclient "github.com/DataDog/watermarkpodautoscaler/third_party/kubernetes/pkg/controller/podautoscaler/metrics"
 	"github.com/go-logr/logr"
@@ -26,10 +27,16 @@ import (
 )
 
 const (
-	aboveHighWatermarkAllowedMessage = "Allow upscaling if the value stays over the Watermark"
-	belowLowWatermarkAllowedMessage  = "Allow downscaling if the value stays under the Watermark"
-	aboveHighWatermarkReason         = "Value above High Watermark"
-	belowLowWatermarkReason          = "Value below Low Watermark"
+	aboveHighWatermarkAllowedMessage      = "Allow upscaling if the value stays over the Watermark"
+	belowLowWatermarkAllowedMessage       = "Allow downscaling if the value stays under the Watermark"
+	convergeToHighWatermarkAllowedMessage = "Allow downscaling to converge to the High Watermark"
+	convergeToLowWatermarkAllowedMessage  = "Allow upscaling to converge to the Low Watermark"
+	convergeToWatermarkStableRegime       = "Converging to Watermark only allowed in stable regime"
+	convergeToWatermarkUnstable           = "Proposal could lead to an unstable regime"
+	convergedToWatermarkDisabled          = "Feature not enabled"
+	aboveHighWatermarkReason              = "Value above High Watermark"
+	belowLowWatermarkReason               = "Value above Low Watermark"
+	convergeToWatermarkAllowedReason      = "Value between Watermarks"
 )
 
 // ReplicaCalculation is used to compute the scaling recommendation.
@@ -221,59 +228,121 @@ func (c *ReplicaCalculator) GetResourceReplicas(logger logr.Logger, target *auto
 	return ReplicaCalculation{replicaCount, utilizationQuantity, timestamp, int32(readyPodCount), metricPos}, nil
 }
 
+func getReplicaCountUpscale(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, adjustedUsage float64, highMark *resource.Quantity) (replicaCount int32) {
+	replicaCount = math32.Ceil(float64(currentReadyReplicas) * adjustedUsage / (float64(highMark.MilliValue())))
+	// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingAbsoluteModulo.
+	if replicaScalingAbsoluteModuloRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingAbsoluteModulo))); replicaScalingAbsoluteModuloRemainder > 0 {
+		replicaCount += *wpa.Spec.ReplicaScalingAbsoluteModulo - replicaScalingAbsoluteModuloRemainder
+	}
+
+	if replicaCount < currentReplicas {
+		logger.Info("Recommendation is lower than current number of replicas while attempting to upscale, aborting", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas)
+		replicaCount = currentReplicas
+	}
+
+	setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusConvergeToWatermark, corev1.ConditionFalse, convergeToHighWatermarkAllowedMessage, convergeToWatermarkStableRegime)
+
+	return replicaCount
+}
+
+func getReplicaCountDownscale(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, adjustedUsage float64, lowMark *resource.Quantity) (replicaCount int32) {
+	replicaCount = math32.Floor(float64(currentReadyReplicas) * adjustedUsage / (float64(lowMark.MilliValue())))
+	// Keep a minimum of 1 replica
+	replicaCount = math32.Max(replicaCount, 1)
+	if replicaScalingAbsoluteModuloRemainder := math32.Mod(replicaCount, *wpa.Spec.ReplicaScalingAbsoluteModulo); replicaScalingAbsoluteModuloRemainder > 0 {
+		// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingAbsoluteModulo.
+		replicaCount += *wpa.Spec.ReplicaScalingAbsoluteModulo - replicaScalingAbsoluteModuloRemainder
+	}
+
+	if replicaCount > currentReplicas {
+		logger.Info("Recommendation is higher than current number of replicas while attempting to downscale, aborting", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas)
+		replicaCount = currentReplicas
+	}
+
+	setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusConvergeToWatermark, corev1.ConditionFalse, convergeToWatermarkStableRegime, convergeToWatermarkStableRegime)
+
+	return replicaCount
+}
+
+// tryToConvergeToWatermark will try to make the replicaCount slowly converge to a watermark.
+// It will suggested converging until the estimated usage goes beyond the respective watermark.
+// This feature is officially only supported with 1 metric.
+func tryToConvergeToWatermark(logger logr.Logger, convergingType v1alpha1.ConvergeTowardsWatermarkType, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, adjustedUsage float64, lowMark, highMark *resource.Quantity) (replicaCount int32) {
+	var optimisedReplicaCount int32
+	scaleBy := *wpa.Spec.ReplicaScalingAbsoluteModulo
+	switch convergingType {
+	case v1alpha1.ConvergeUpwards:
+		optimisedReplicaCount = math32.Max(currentReplicas-scaleBy, 1)
+		currentReadyReplicasAfterDownscale := math32.Max(currentReadyReplicas-scaleBy, 0)
+		adjustedUsageAfterDownscale := math.Ceil(adjustedUsage * float64(currentReadyReplicas) / float64(currentReadyReplicasAfterDownscale))
+
+		if int64(adjustedUsageAfterDownscale) > highMark.MilliValue() {
+			// This would result in a downscale, give up
+			setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusConvergeToWatermark, corev1.ConditionFalse, convergeToHighWatermarkAllowedMessage, convergeToWatermarkUnstable)
+			logger.Info("Scaling down would likely make the usage go above the High Watermark", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "currentReadyReplicasAfterDownscale", currentReadyReplicasAfterDownscale, "adjustedUsageAfterDownscale", adjustedUsageAfterDownscale, "highMark", highMark.MilliValue())
+			return currentReplicas
+		}
+		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusConvergeToWatermark, corev1.ConditionTrue, convergeToHighWatermarkAllowedMessage, convergeToWatermarkAllowedReason)
+		// This should stay under HW
+		logger.Info("Trying to scale down to converge to High Watermark", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "currentReplicasAfterDownscale", optimisedReplicaCount, "currentReadyReplicasAfterDownscale", currentReadyReplicasAfterDownscale, "adjustedUsageAfterDownscale", adjustedUsageAfterDownscale, "highMark", highMark.MilliValue())
+
+	case v1alpha1.ConvergeDownwards:
+		optimisedReplicaCount = currentReplicas + scaleBy
+		currentReadyReplicasUpscale := currentReadyReplicas + scaleBy
+		adjustedUsageAfterUpscale := math.Ceil(adjustedUsage * float64(currentReadyReplicas) / float64(currentReadyReplicasUpscale))
+
+		if int64(adjustedUsageAfterUpscale) < lowMark.MilliValue() {
+			// This would result in an upscale, give up
+			setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusConvergeToWatermark, corev1.ConditionFalse, convergeToLowWatermarkAllowedMessage, convergeToWatermarkUnstable)
+			logger.Info("Scaling up would likely make the usage go below the Low Watermark", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "currentReadyReplicasUpscale", currentReadyReplicasUpscale, "currentReadyReplicasUpscale", currentReadyReplicasUpscale, "lowMark", lowMark.MilliValue())
+			return currentReplicas
+		}
+		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusConvergeToWatermark, corev1.ConditionTrue, convergeToLowWatermarkAllowedMessage, convergeToWatermarkAllowedReason)
+		// This should stay under HW
+		logger.Info("Trying to scale up to converge to Low Watermark", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "currentReplicasAfterDownscale", optimisedReplicaCount, "currentReadyReplicasUpscale", currentReadyReplicasUpscale, "currentReadyReplicasUpscale", currentReadyReplicasUpscale, "lowMark", lowMark.MilliValue())
+
+	default:
+		setCondition(wpa, v1alpha1.WatermarkPodAutoscalerStatusConvergeToWatermark, corev1.ConditionFalse, convergedToWatermarkDisabled, convergeToWatermarkAllowedReason)
+		optimisedReplicaCount = currentReplicas
+	}
+	return optimisedReplicaCount
+}
+
 func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, name string, adjustedUsage float64, lowMark, highMark *resource.Quantity) (replicaCount int32, utilization int64, position metricPosition) {
 	utilizationQuantity := resource.NewMilliQuantity(int64(adjustedUsage), resource.DecimalSI)
-	adjustedHM := float64(highMark.MilliValue() + highMark.MilliValue()*wpa.Spec.Tolerance.MilliValue()/1000)
-	adjustedLM := float64(lowMark.MilliValue() - lowMark.MilliValue()*wpa.Spec.Tolerance.MilliValue()/1000)
+	adjustedHM := float64(highMark.MilliValue() + highMark.MilliValue()*wpa.Spec.Tolerance.MilliValue()/1000.)
+	adjustedLM := float64(lowMark.MilliValue() - lowMark.MilliValue()*wpa.Spec.Tolerance.MilliValue()/1000.)
 
 	labelsWithReason := prometheus.Labels{wpaNamePromLabel: wpa.Name, wpaNamespacePromLabel: wpa.Namespace, resourceNamespacePromLabel: wpa.Namespace, resourceNamePromLabel: wpa.Spec.ScaleTargetRef.Name, resourceKindPromLabel: wpa.Spec.ScaleTargetRef.Kind, reasonPromLabel: withinBoundsPromLabelVal}
 	labelsWithMetricName := prometheus.Labels{wpaNamePromLabel: wpa.Name, wpaNamespacePromLabel: wpa.Namespace, resourceNamespacePromLabel: wpa.Namespace, resourceNamePromLabel: wpa.Spec.ScaleTargetRef.Name, resourceKindPromLabel: wpa.Spec.ScaleTargetRef.Kind, metricNamePromLabel: name}
 
+	value.With(labelsWithMetricName).Set(adjustedUsage)
+	msg := ""
+
 	switch {
+	// Upscale if usage > hw
 	case adjustedUsage > adjustedHM:
-		replicaCount = int32(math.Ceil(float64(currentReadyReplicas) * adjustedUsage / (float64(highMark.MilliValue()))))
-		// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingAbsoluteModulo.
-		if replicaScalingAbsoluteModuloRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingAbsoluteModulo))); replicaScalingAbsoluteModuloRemainder > 0 {
-			replicaCount += *wpa.Spec.ReplicaScalingAbsoluteModulo - replicaScalingAbsoluteModuloRemainder
-		}
-		// tolerance: milliValue/10 to represent the %.
-		logger.Info("Value is above highMark", "usage", utilizationQuantity.String(), "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "tolerance (%)", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedHM", adjustedHM, "adjustedUsage", adjustedUsage)
-		if replicaCount < currentReplicas {
-			logger.Info("Recommendation is lower than current number of replicas while attempting to upscale, aborting", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas)
-			replicaCount = currentReplicas
-		}
+		msg = "Value is above highMark"
+		restrictedScaling.With(labelsWithReason).Set(0)
+		replicaCount = getReplicaCountUpscale(logger, currentReplicas, currentReadyReplicas, wpa, adjustedUsage, highMark)
 		position.isAbove = true
 		position.isBelow = false
-
+	// Downscale if usage < lw
 	case adjustedUsage < adjustedLM:
-		replicaCount = int32(math.Floor(float64(currentReadyReplicas) * adjustedUsage / (float64(lowMark.MilliValue()))))
-		// Keep a minimum of 1 replica
-		replicaCount = int32(math.Max(float64(replicaCount), 1))
-		if replicaScalingAbsoluteModuloRemainder := int32(math.Mod(float64(replicaCount), float64(*wpa.Spec.ReplicaScalingAbsoluteModulo))); replicaScalingAbsoluteModuloRemainder > 0 {
-			// Scale up the computed replica count so that it is evenly divisible by the ReplicaScalingAbsoluteModulo.
-			replicaCount += *wpa.Spec.ReplicaScalingAbsoluteModulo - replicaScalingAbsoluteModuloRemainder
-		}
-		logger.Info("Value is below lowMark", "usage", utilizationQuantity.String(), "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "tolerance (%)", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedLM", adjustedLM, "adjustedUsage", adjustedUsage)
-		if replicaCount > currentReplicas {
-			logger.Info("Recommendation is higher than current number of replicas while attempting to downscale, aborting", "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas)
-			replicaCount = currentReplicas
-		}
-
+		msg = "Value is below lowMark"
+		restrictedScaling.With(labelsWithReason).Set(0)
+		replicaCount = getReplicaCountDownscale(logger, currentReplicas, currentReadyReplicas, wpa, adjustedUsage, lowMark)
 		position.isAbove = false
 		position.isBelow = true
-
+	// If within bounds, do nothing unless converging is enabled
 	default:
-		restrictedScaling.With(labelsWithReason).Set(1)
-		value.With(labelsWithMetricName).Set(adjustedUsage)
-		logger.Info("Within bounds of the watermarks", "value", utilizationQuantity.String(), "currentReadyReplicas", currentReadyReplicas, "tolerance (%)", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedLM", adjustedLM, "adjustedHM", adjustedHM, "adjustedUsage", adjustedUsage)
+		msg = "Within bounds of the watermarks"
 		position.isAbove = false
 		position.isBelow = false
-		// returning the currentReplicas instead of the count of healthy ones to be consistent with the upstream behavior.
-		return currentReplicas, utilizationQuantity.MilliValue(), position
+		replicaCount = tryToConvergeToWatermark(logger, wpa.Spec.ConvergeTowardsWatermark, currentReplicas, currentReadyReplicas, wpa, adjustedUsage, lowMark, highMark)
 	}
 
-	restrictedScaling.With(labelsWithReason).Set(0)
-	value.With(labelsWithMetricName).Set(adjustedUsage)
+	logger.Info(msg, "usage", utilizationQuantity.String(), "replicaCount", replicaCount, "currentReadyReplicas", currentReadyReplicas, "tolerance (%)", float64(wpa.Spec.Tolerance.MilliValue())/10, "adjustedLM", adjustedLM, "adjustedHM", adjustedHM, "adjustedUsage", adjustedUsage)
 
 	return replicaCount, utilizationQuantity.MilliValue(), position
 }

--- a/controllers/replica_calculator_test.go
+++ b/controllers/replica_calculator_test.go
@@ -445,6 +445,176 @@ func TestScaleIntervalReplicaCalcNoScale(t *testing.T) {
 	tc.runTest(t)
 }
 
+func TestScaleIntervalReplicaCalcConvergeNoScaleDown(t *testing.T) {
+	logf.SetLogger(zap.New())
+	metric1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ResourceMetricSourceType,
+		Resource: &v1alpha1.ResourceMetricSource{
+			Name:           corev1.ResourceCPU,
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "test-pod"}},
+			HighWatermark:  resource.NewMilliQuantity(40000, resource.DecimalSI),
+			LowWatermark:   resource.NewMilliQuantity(20000, resource.DecimalSI),
+		},
+	}
+
+	tc := replicaCalcTestCase{
+		expectedReplicas: 3, // We're not going to scale down because that would bring the utilization to 40500 which would be above HW
+		readyReplicas:    3,
+		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		wpa: &v1alpha1.WatermarkPodAutoscaler{
+			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
+				ConvergeTowardsWatermark:     "highwatermark",
+			},
+		},
+		metric: &metricInfo{
+			spec:                metric1,
+			levels:              []int64{9000, 9000, 9000}, // We are between the high and low watermarks.
+			expectedUtilization: 27000,
+		},
+	}
+	tc.runTest(t)
+}
+
+func TestScaleIntervalReplicaCalcConvergeDefault(t *testing.T) {
+	logf.SetLogger(zap.New())
+	metric1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ResourceMetricSourceType,
+		Resource: &v1alpha1.ResourceMetricSource{
+			Name:           corev1.ResourceCPU,
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "test-pod"}},
+			HighWatermark:  resource.NewMilliQuantity(40000, resource.DecimalSI),
+			LowWatermark:   resource.NewMilliQuantity(20000, resource.DecimalSI),
+		},
+	}
+
+	tc := replicaCalcTestCase{
+		expectedReplicas: 3, // We're not going to scale down because that would bring the utilization to 40500 which would be above HW
+		readyReplicas:    3,
+		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		wpa: &v1alpha1.WatermarkPodAutoscaler{
+			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
+				ConvergeTowardsWatermark:     "",
+			},
+		},
+		metric: &metricInfo{
+			spec:                metric1,
+			levels:              []int64{9000, 9000, 9000}, // We are between the high and low watermarks.
+			expectedUtilization: 27000,
+		},
+	}
+	tc.runTest(t)
+}
+
+func TestScaleIntervalReplicaCalcConvergeNoScaleUp(t *testing.T) {
+	logf.SetLogger(zap.New())
+	metric1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ResourceMetricSourceType,
+		Resource: &v1alpha1.ResourceMetricSource{
+			Name:           corev1.ResourceCPU,
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "test-pod"}},
+			HighWatermark:  resource.NewMilliQuantity(40000, resource.DecimalSI),
+			LowWatermark:   resource.NewMilliQuantity(27000, resource.DecimalSI),
+		},
+	}
+
+	tc := replicaCalcTestCase{
+		expectedReplicas: 3, // We're not going to scale down because that would bring the utilization to 40500 which would be above HW
+		readyReplicas:    3,
+		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		wpa: &v1alpha1.WatermarkPodAutoscaler{
+			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
+				ConvergeTowardsWatermark:     "lowwatermark",
+			},
+		},
+		metric: &metricInfo{
+			spec:                metric1,
+			levels:              []int64{9000, 9000, 9000}, // We are between the high and low watermarks.
+			expectedUtilization: 27000,
+		},
+	}
+	tc.runTest(t)
+}
+
+func TestScaleIntervalReplicaCalcConvergeScaleUp(t *testing.T) {
+	logf.SetLogger(zap.New())
+	metric1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ResourceMetricSourceType,
+		Resource: &v1alpha1.ResourceMetricSource{
+			Name:           corev1.ResourceCPU,
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "test-pod"}},
+			HighWatermark:  resource.NewMilliQuantity(40000, resource.DecimalSI),
+			LowWatermark:   resource.NewMilliQuantity(20000, resource.DecimalSI),
+		},
+	}
+
+	tc := replicaCalcTestCase{
+		expectedReplicas: 4, // We're scale up because the utilization gets to 27000 which would be still above the LW
+		readyReplicas:    3,
+		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		wpa: &v1alpha1.WatermarkPodAutoscaler{
+			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
+				ConvergeTowardsWatermark:     "lowwatermark",
+			},
+		},
+		metric: &metricInfo{
+			spec:                metric1,
+			levels:              []int64{9000, 9000, 9000}, // We are between the high and low watermarks.
+			expectedUtilization: 27000,
+		},
+	}
+	tc.runTest(t)
+}
+
+func TestScaleIntervalReplicaCalcConvergeScaleDown(t *testing.T) {
+	logf.SetLogger(zap.New())
+	metric1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ResourceMetricSourceType,
+		Resource: &v1alpha1.ResourceMetricSource{
+			Name:           corev1.ResourceCPU,
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"name": "test-pod"}},
+			HighWatermark:  resource.NewMilliQuantity(40000, resource.DecimalSI),
+			LowWatermark:   resource.NewMilliQuantity(20000, resource.DecimalSI),
+		},
+	}
+
+	tc := replicaCalcTestCase{
+		expectedReplicas: 2,
+		readyReplicas:    3,
+		scale:            makeScale(testDeploymentName, 3, map[string]string{"name": "test-pod"}),
+		wpa: &v1alpha1.WatermarkPodAutoscaler{
+			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
+				Algorithm:                    "absolute",
+				Tolerance:                    *resource.NewMilliQuantity(25, resource.DecimalSI), // 25m represents 2.5%
+				Metrics:                      []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo: v1alpha1.NewInt32(1),
+				ConvergeTowardsWatermark:     "highwatermark",
+			},
+		},
+		metric: &metricInfo{
+			spec:                metric1,
+			levels:              []int64{8000, 8000, 8000}, // We are between the high and low watermarks.
+			expectedUtilization: 24000,
+		},
+	}
+	tc.runTest(t)
+}
+
 func TestReplicaCalcAbsoluteScaleDown(t *testing.T) {
 	logf.SetLogger(zap.New())
 	metric1 := v1alpha1.MetricSpec{

--- a/pkg/math32/math32.go
+++ b/pkg/math32/math32.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package math32 package contains utils to manipulate the different types.
+package math32
+
+import "math"
+
+// Max returns the maximum of y and x.
+func Max(x, y int32) int32 {
+	if x < y {
+		return y
+	}
+	return x
+}
+
+// Floor returns the greatest integer value less than or equal to x.
+func Floor(a float64) int32 {
+	return int32(math.Floor(a))
+}
+
+// Ceil returns the least integer value greater than or equal to x.
+func Ceil(a float64) int32 {
+	return int32(math.Ceil(a))
+}
+
+// Mod returns the floating-point remainder of x/y.
+func Mod(x int32, y int32) int32 {
+	return int32(math.Mod(float64(x), float64(y)))
+}


### PR DESCRIPTION
### What does this PR do?

Based on the work of @iksaif in https://github.com/DataDog/watermarkpodautoscaler/pull/160.
The goal of this PR is to introduce a feature that will have the controller attempt to converge towards a watermark of their choice.

The option is `Spec.ConvergeTowardsWatermark` and has 2 values: `lowwatermark` and `highwatermark`.
If used, when a metric is in stable regime (i.e. between its watermark), the controller will evaluate whether adding/removing `.Spec.ReplicaScalingAbsoluteModulo` would make the value of the metric lead to an unstable regime (value out of the watermarks).

The recommended value will still go through the filters (scaling velocity, min/max replicas, forbidden windows, scalingDelay).

### Motivation

This feature is not officially supported for multiple metrics. While the logic supports it and will follow the core logic of using the greatest recommendation, the status needs refactoring in order to provide granular insight.

### Additional notes
