### PR TITLE
Update manager field

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,9 @@ func main() {
 	version.PrintVersionLogs(setupLog)
 
 	syncDuration := time.Duration(syncPeriodSeconds) * time.Second
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), config.ManagerOptionsWithNamespaces(setupLog, ctrl.Options{
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.UserAgent = "wpa-controller"
+	mgr, err := ctrl.NewManager(restConfig, config.ManagerOptionsWithNamespaces(setupLog, ctrl.Options{
 		Scheme:                     scheme,
 		MetricsBindAddress:         fmt.Sprintf("%s:%d", host, metricsPort),
 		Port:                       9443,


### PR DESCRIPTION
### What does this PR do?

Configure a controller manager name, `wpa-controller` for the `manager` managedField. 

### Motivation

Previously, the `WatermarkPodAutoscaler` resource created by the wpa-controller had the managed field, `Manager: manager`, which was ambiguous and confusing. 

```
Name: example-watermarkpodautoscaler
[...]
API Version:  datadoghq.com/v1alpha1
Kind:         WatermarkPodAutoscaler
Metadata:
[...]
  Managed Fields:
[...]
    Manager:      manager
[...]
    Manager:      manager
```

This change customizes the `Manager` name to a more meaningful name, `wpa-controller`. 

```
Name: example-watermarkpodautoscaler
[...]
API Version:  datadoghq.com/v1alpha1
Kind:         WatermarkPodAutoscaler
Metadata:
[...]
  Managed Fields:
[...]
    Manager:      wpa-controller
[...]
    Manager:      wpa-controller
```

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

1. Deploy wpa-controller
2. Deploy a `WatermarkPodAutoscaler` manifest file
3. Check that the `WatermarkPodAutoscaler` CRD field `Metadata.Managed Fields.Manager` is `wpa-controller`
