### PR TITLE
Add scaling events count to kubectl output

### DIFF
--- a/api/v1alpha1/watermarkpodautoscaler_types.go
+++ b/api/v1alpha1/watermarkpodautoscaler_types.go
@@ -26,6 +26,7 @@ import (
 // +kubebuilder:printcolumn:name="max replicas",type="integer",JSONPath=".spec.maxReplicas"
 // +kubebuilder:printcolumn:name="dry-run",type="string",JSONPath=".status.conditions[?(@.type==\"DryRun\")].status"
 // +kubebuilder:printcolumn:name="last scale",type="date",JSONPath=".status.lastScaleTime"
+// +kubebuilder:printcolumn:name="scale count",type="integer",priority=1,JSONPath=".status.scalingEventsCount"
 // +kubebuilder:resource:path=watermarkpodautoscalers,shortName=wpa
 // +k8s:openapi-gen=true
 // +genclient
@@ -211,6 +212,7 @@ type MetricSpec struct {
 type WatermarkPodAutoscalerStatus struct {
 	ObservedGeneration *int64       `json:"observedGeneration,omitempty"`
 	LastScaleTime      *metav1.Time `json:"lastScaleTime,omitempty"`
+	ScalingEventsCount int32        `json:"scalingEventsCount,omitempty"`
 	CurrentReplicas    int32        `json:"currentReplicas"`
 	DesiredReplicas    int32        `json:"desiredReplicas"`
 	// +optional

--- a/api/v1alpha1/zz_generated.openapi.go
+++ b/api/v1alpha1/zz_generated.openapi.go
@@ -386,6 +386,12 @@ func schema__api_v1alpha1_WatermarkPodAutoscalerStatus(ref common.ReferenceCallb
 							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
+					"scalingEventsCount": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 					"currentReplicas": {
 						SchemaProps: spec.SchemaProps{
 							Default: 0,

--- a/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -52,6 +52,10 @@ spec:
     - jsonPath: .status.lastScaleTime
       name: last scale
       type: date
+    - jsonPath: .status.scalingEventsCount
+      name: scale count
+      priority: 1
+      type: integer
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -733,6 +737,9 @@ spec:
                 type: string
               observedGeneration:
                 format: int64
+                type: integer
+              scalingEventsCount:
+                format: int32
                 type: integer
             required:
             - currentReplicas

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -42,6 +42,10 @@ spec:
     - JSONPath: .status.lastScaleTime
       name: last scale
       type: date
+    - JSONPath: .status.scalingEventsCount
+      name: scale count
+      priority: 1
+      type: integer
   group: datadoghq.com
   names:
     kind: WatermarkPodAutoscaler
@@ -548,6 +552,9 @@ spec:
               type: string
             observedGeneration:
               format: int64
+              type: integer
+            scalingEventsCount:
+              format: int32
               type: integer
           required:
             - currentReplicas

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -460,6 +460,7 @@ func setStatus(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, currentReplicas, d
 	if rescale {
 		now := metav1.NewTime(time.Now())
 		wpa.Status.LastScaleTime = &now
+		wpa.Status.ScalingEventsCount += 1
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Adds a total count of scaling events to `kubectl describe` and `kubectl get -o wide` commands:

get output:
```shell   
$ kubectl get wpa -o wide
NAME   SCALING ACTIVE   CONDITION     CONDITION STATE   VALUE   HIGH WATERMARK   LOW WATERMARK   AGE   MIN REPLICAS   MAX REPLICAS   DRY-RUN   LAST SCALE   SCALE COUNT
wpa    True             AbleToScale   False             10      15               1               10s   1              2              False     6s           1                
```

describe output:
```
$ kubectl describe wpa wpa
Name:         wpa
Namespace:    default
[...]
  Last Scale Time:            2023-07-10T21:50:28Z
  Scaling Events Count:       2
```

### Motivation

If it's not possible to look at metrics or parse through logs to confirm scaling events are still occurring during an outage, an increasing number of `Scaling Events Count` would indicate that the WPA was still able to scale up/down

### Additional Notes

The output of `kubectl get` already includes a lot of information and since the purpose of this counter is for use in the (hopefully) unlikely case of unavailable metrics, the `SCALE COUNT` is only available in the `kubectl get -o wide` view. It is always available in a `kubectl describe` output

### Describe your test plan

Scale several WPAs multiple times and ensure the scale count total is correct for each WPA
