### PR TITLE
Fix path in script to release plugin

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,7 +162,7 @@ jobs:
           mv ./tmp-build/windows/*.zip ./dist
           cp ./tmp-build/linux/CHANGELOG.md ./dist/CHANGELOG.md
       - name: Generate Plugin manifest
-        run: ./hack/release/generate-plugin-manifest.sh ${{steps.tag.outputs.tag}}
+        run: ./hack/plugin/generate-plugin-manifest.sh ${{steps.tag.outputs.tag}}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
### What does this PR do?

Fix the correct path to find the script to release the plugin.
Fixes:
```
/home/runner/work/_temp/67bcaacd-428d-4afd-bf75-b35371ccc87f.sh: line 1: ./hack/release/generate-plugin-manifest.sh: No such file or directory
Error: Process completed with exit code 127.
```

### Motivation

Release 060

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
