### PR TITLE
Respect Pod deletionTimestamp to avoid accounting for replicas being rotated

### DIFF
--- a/controllers/replica_calculator.go
+++ b/controllers/replica_calculator.go
@@ -358,8 +358,9 @@ func (c *ReplicaCalculator) getReadyPodsCount(log logr.Logger, targetName string
 		_, condition := getPodCondition(&pod.Status, corev1.PodReady)
 		// We can't distinguish pods that are past the Readiness in the lifecycle but have not reached it
 		// and pods that are still Unschedulable but we don't need this level of granularity.
-		if condition == nil || pod.Status.StartTime == nil {
-			log.Info("Pod unready", "namespace", pod.Namespace, "name", pod.Name)
+		// We do not want to account for pods that are being deleted either.
+		if condition == nil || pod.Status.StartTime == nil || pod.DeletionTimestamp != nil {
+			log.V(2).Info("Pod unready", "namespace", pod.Namespace, "name", pod.Name)
 			continue
 		}
 		if pod.Status.Phase == corev1.PodRunning && condition.Status == corev1.ConditionTrue ||


### PR DESCRIPTION
### What does this PR do?

During rolling updates a `maxSurge` number of pods will be created on top of what the deployment has in its spec.
This can lead to a greater number of replicas observed than expected and could even lead to unexpected scale up events.

### Motivation

Long term vision is to support events such as rolling updates in the lifecycle of the WPA, for now, this will allow for more sane behaviors.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Create a deployment with:
```
spec.template.spec.terminationGracePeriodSeconds: 600
```
Make sure that in the logs of the WPA, the "tolerated as ready pods" only accounts for the pods that have not been marked with a deletionTimestamp (i.e. old replicaset that has not been rotated and new replicaset maxsurge).
For a workload that has a WPA:
```
➜  ~ k get deploy alpine -ojson | jq .spec.replicas
10
```
create a rolling update. 
i.e. you will see:
```
[...]
alpine-6bf464d777-kznt5                  1/1     Terminating   0              8m40s
alpine-6bf464d777-lrmls                  1/1     Terminating   0              8m37s
alpine-6bf464d777-mfqnd                  1/1     Terminating   0              8m38s
alpine-6bf464d777-qtpf5                  1/1     Terminating   0              8m37s
alpine-6bf464d777-ssjb7                  1/1     Terminating   0              8m37s
alpine-6bf464d777-thxbg                  1/1     Terminating   0              8m37s
alpine-b6b55bb6f-5b6c7                   1/1     Running       0              62s
alpine-b6b55bb6f-5sxx7                   1/1     Running       0              61s
alpine-b6b55bb6f-b55x7                   1/1     Running       0              63s
[...]
```
pre fix:
```
{"level":"info","ts":1696971338321.353,"logger":"controllers.WatermarkPodAutoscaler","msg":"getReadyPodsCount","watermarkpodautoscaler":"default/example-watermarkpodautoscaler","wpa_name":"example-watermarkpodautoscaler","wpa_namespace":"default","full podList length":20,"toleratedAsReadyPodCount":20,"incorrectly targeted pods":0}
```
post fix
```
{"level":"info","ts":1696971275384.844,"logger":"controllers.WatermarkPodAutoscaler","msg":"getReadyPodsCount","watermarkpodautoscaler":"default/example-watermarkpodautoscaler","wpa_name":"example-watermarkpodautoscaler","wpa_namespace":"default","full podList length":20,"toleratedAsReadyPodCount":10,"incorrectly targeted pods":0}
```