### PR TITLE
Checking if LC annotation is empty to avoid spammy log

### DIFF
--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -164,8 +164,9 @@ func (r *WatermarkPodAutoscalerReconciler) Reconcile(ctx context.Context, reques
 		return reconcile.Result{}, nil
 	}
 
-	enabled, err := strconv.ParseBool(instance.Annotations[lifecycleControlEnabledAnnotationKey])
-	if err != nil {
+	enabledValue := instance.Annotations[lifecycleControlEnabledAnnotationKey]
+	enabled, err := strconv.ParseBool(enabledValue)
+	if err != nil && enabledValue != "" {
 		log.Error(err, "lifecycle control config annotation could not be parsed, it will be ignored")
 		setCondition(instance, datadoghqv1alpha1.ScalingBlocked, corev1.ConditionFalse, datadoghqv1alpha1.ReasonFailedGetDatadogMonitor, fmt.Sprintf("Lifecycle Control is not correctly enabled: %s", err.Error()))
 	}


### PR DESCRIPTION
### What does this PR do?

Without this check we always check if the lifecycle control value is a boolean and if the feature is not used, it just outputs an unnecessary  error log:
```
{"level":"error","ts":1706300991708.4353,"logger":"controllers.WatermarkPodAutoscaler","msg":"lifecycle control config annotation could not be parsed, it will be ignored","watermarkpodautoscaler":"datadog-agent/datadog-agent-cluster-worker-watermarkpodautoscaler","wpa_name":"datadog-agent-cluster-worker-watermarkpodautoscaler","wpa_namespace":"datadog-agent","error":"strconv.ParseBool: parsing \"\": invalid syntax"}
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
