### PR TITLE
Make generating NotScale events configurable; use logs when disabled

### DIFF
--- a/api/v1alpha1/const.go
+++ b/api/v1alpha1/const.go
@@ -30,10 +30,10 @@ const (
 	ConditionReasonFailedGetResourceMetric = "FailedGetResourceMetric"
 	// ConditionValidMetricFound Condition when a valid metric is retrieved
 	ConditionValidMetricFound = "ValidMetricFound"
+	// CondistionReasonNotScaling Condition reason when not scaling
+	ConditionReasonNotScaling = "NotScaling"
 	// ReasonFailedSpecCheck Reason when the spec of the WPA is incorrect
 	ReasonFailedSpecCheck = "FailedSpecCheck"
-	// ReasonNotScaling Reason when not scaling
-	ReasonNotScaling = "NotScaling"
 	// ReasonScaling Reason when scaling
 	ReasonScaling = "Scaling"
 	// ReasonFailedScale Reason when unable to scale

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -379,9 +379,10 @@ func (r *WatermarkPodAutoscalerReconciler) reconcileWPA(ctx context.Context, log
 		logger.Info("Successful rescale", "currentReplicas", currentReplicas, "desiredReplicas", desiredReplicas, "rescaleReason", rescaleReason)
 	} else {
 		if r.Options.SkipNotScalingEvents {
+			setCondition(wpa, autoscalingv2.ScalingActive, corev1.ConditionTrue, datadoghqv1alpha1.ConditionReasonNotScaling, "the WPA was able to successfully calculate a replica count and decided not to scale %s to %d (last scale time was %v )", reference, desiredReplicas, wpa.Status.LastScaleTime)
 			logger.Info(fmt.Sprintf("Decided not to scale %s to %d (last scale time was %v )", reference, desiredReplicas, wpa.Status.LastScaleTime))
 		} else {
-			r.eventRecorder.Eventf(wpa, corev1.EventTypeNormal, datadoghqv1alpha1.ReasonNotScaling, fmt.Sprintf("Decided not to scale %s to %d (last scale time was %v )", reference, desiredReplicas, wpa.Status.LastScaleTime))
+			r.eventRecorder.Eventf(wpa, corev1.EventTypeNormal, datadoghqv1alpha1.ConditionReasonNotScaling, fmt.Sprintf("Decided not to scale %s to %d (last scale time was %v )", reference, desiredReplicas, wpa.Status.LastScaleTime))
 		}
 
 		desiredReplicas = currentReplicas

--- a/controllers/watermarkpodautoscaler_controller.go
+++ b/controllers/watermarkpodautoscaler_controller.go
@@ -380,7 +380,6 @@ func (r *WatermarkPodAutoscalerReconciler) reconcileWPA(ctx context.Context, log
 	} else {
 		if r.Options.SkipNotScalingEvents {
 			setCondition(wpa, autoscalingv2.ScalingActive, corev1.ConditionTrue, datadoghqv1alpha1.ConditionReasonNotScaling, "the WPA was able to successfully calculate a replica count and decided not to scale %s to %d (last scale time was %v )", reference, desiredReplicas, wpa.Status.LastScaleTime)
-			logger.Info(fmt.Sprintf("Decided not to scale %s to %d (last scale time was %v )", reference, desiredReplicas, wpa.Status.LastScaleTime))
 		} else {
 			r.eventRecorder.Eventf(wpa, corev1.EventTypeNormal, datadoghqv1alpha1.ConditionReasonNotScaling, fmt.Sprintf("Decided not to scale %s to %d (last scale time was %v )", reference, desiredReplicas, wpa.Status.LastScaleTime))
 		}


### PR DESCRIPTION
### What does this PR do?

Add skipNotScalingEvents config option in WPA to disable NotScaling Kubernetes events. When disabled this will generate a log instead and update the `Status` of the WPA. 

### Motivation

Eliminate WPA error logs that are the result of the Kubernetes API server rate limiting WPA event writes

### Additional Notes

- When updating the `Status` we use the `ScalingActive` Condition Type. This is initially set [here](https://github.com/DataDog/watermarkpodautoscaler/blob/levipe01/notscale-events-config-option/controllers/watermarkpodautoscaler_controller.go#L687) and we override the condition & message to show that the replicas are correctly calculated, however we are choosing not to scale.
- Leaving the default behavior to continue to write Kubernetes Events in the event that 3rd party users are currently monitoring on these.

### Describe your test plan

- Enabling this feature should result in the Kubernetes events with a message of `Decided not to scale` to appear as logs instead.
- When describing the WPA object you should see the `Status` update with a message like the below when not scaling.
```
Status:
  Conditions:
    Last Transition Time:  2024-03-21T21:46:18Z
    Message:               the WPA was able to successfully calculate a replica count and decided not to scale Deployment/datadog/php-apache to 9 (last scale time was 2024-03-21 21:27:48 +0000 UTC )
    Reason:                NotScaling
    Status:                True
    Type:                  ScalingActive
```