### PR TITLE
metrics: add count for number of upscale and downscale

### DIFF
--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -43,6 +43,34 @@ var reasonValues = []string{downscaleCappingPromLabelVal, upscaleCappingPromLabe
 var extraPromLabels = strings.Fields(os.Getenv("DD_LABELS_AS_TAGS"))
 
 var (
+	upscale = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "upscale_replicas_total",
+			Help:      "",
+		},
+		[]string{
+			wpaNamePromLabel,
+			wpaNamespacePromLabel,
+			resourceNamespacePromLabel,
+			resourceNamePromLabel,
+			resourceKindPromLabel,
+		},
+	)
+	downscale = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "downscale_replicas_total",
+			Help:      "",
+		},
+		[]string{
+			wpaNamePromLabel,
+			wpaNamespacePromLabel,
+			resourceNamespacePromLabel,
+			resourceNamePromLabel,
+			resourceKindPromLabel,
+		},
+	)
 	value = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Subsystem: subsystem,
@@ -306,4 +334,14 @@ func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onl
 		monitorName:           wpa.Name,
 		monitorNamespace:      wpa.Namespace,
 	})
+}
+
+func getPrometheusLabels(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler) prometheus.Labels {
+	return prometheus.Labels{
+		wpaNamePromLabel:           wpa.Name,
+		wpaNamespacePromLabel:      wpa.Namespace,
+		resourceNamePromLabel:      wpa.Spec.ScaleTargetRef.Name,
+		resourceNamespacePromLabel: wpa.Namespace,
+		resourceKindPromLabel:      wpa.Spec.ScaleTargetRef.Kind,
+	}
 }


### PR DESCRIPTION
Motivation
----------
Currently the wpa controlleur is only exposing a logs to inform of any upscale/downscale. It would be very useful to have a metric on upscale/downscale in order to be able to visualize them.

see: https://github.com/DataDog/watermarkpodautoscaler/blob/9adcbcf5a9df4bb6b4370820dead417afa7c6932/controllers/watermarkpodautoscaler_controller.go#L379

Scope
------
Create two count metrics:
- `watermarkpodautoscaler.wpa_controller_upscale_replicas_total`: count the number of upscale done
- `watermarkpodautoscaler.wpa_controller_downscale_replicas_total`: count the number of down scale

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
