### PR TITLE
fix(ci): use new goreleaser parameter

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: build --skip-validate --config .goreleaser-for-linux.yaml
+          args: build --skip=validate --config .goreleaser-for-linux.yaml
   build-darwin-binary:
     runs-on: macos-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: build --skip-validate --config .goreleaser-for-darwin.yaml
+          args: build --skip=validate --config .goreleaser-for-darwin.yaml
   build-windows-binary:
     runs-on: ubuntu-latest
     steps:
@@ -61,4 +61,4 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: build --skip-validate --config .goreleaser-for-windows.yaml
+          args: build --skip=validate --config .goreleaser-for-windows.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --skip-publish --config .goreleaser-for-linux.yaml
+          args: release --skip=publish --config .goreleaser-for-linux.yaml
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload
@@ -75,7 +75,7 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: release --skip-publish --config .goreleaser-for-darwin.yaml
+          args: release --skip=publish --config .goreleaser-for-darwin.yaml
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload
@@ -109,7 +109,7 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v3
         with:
-          args: release --skip-publish --config .goreleaser-for-windows.yaml
+          args: release --skip=publish --config .goreleaser-for-windows.yaml
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload


### PR DESCRIPTION
### What does this PR do?

update the CI configuration to use new goreleaser parameter options instead of the deprecated options

### Motivation

`--skip-publish` and `--skip-validate` arguments are deprecated in favour of `--skip=publish` and --skip=validate

an example of a failing job https://github.com/DataDog/watermarkpodautoscaler/actions/runs/9570721706/job/26386235301 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
