### PR TITLE
fix(ci): migrate to registry.ddbuild.io for ci images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
   GOPATH: "$CI_PROJECT_DIR/.cache"
   TARGET_TAG: v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA
   BUILD_DOCKER_REGISTRY: "registry.ddbuild.io/ci"
-  JOB_DOCKER_IMAGE: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-containers-project:v2.0.0"
+  JOB_DOCKER_IMAGE: "registry.ddbuild.io/ci-containers-project:v2.0.0"
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
@@ -45,27 +45,14 @@ generate_code:
     - make generate
     - git diff --exit-code
 
-build_image_amd64:
+build_image:
   stage: image
   tags:
     - "arch:amd64"
   image: $JOB_DOCKER_IMAGE
   variables:
-    GOARCH: amd64
-    TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-  script:
-    - IMG=$TARGET_IMAGE make docker-buildx-ci
-
-build_image_arm64:
-  stage: image
-  tags:
-    - "arch:arm64"
-  image: $JOB_DOCKER_IMAGE
-  variables:
-    GOARCH: arm64
-    TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
-    RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
   script:
     - IMG=$TARGET_IMAGE make docker-buildx-ci
 
@@ -80,7 +67,7 @@ publish_public_main:
     branch: main
     strategy: depend
   variables:
-    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: $PROJECTNAME:main
     IMG_SIGNING: "false"
 
@@ -95,7 +82,7 @@ publish_public_tag:
     branch: main
     strategy: depend
   variables:
-    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG
     IMG_DESTINATIONS: $PROJECTNAME:$CI_COMMIT_TAG
     IMG_SIGNING: "false"
 
@@ -110,7 +97,7 @@ publish_public_latest:
     branch: main
     strategy: depend
   variables:
-    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64,$BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
+    IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG
     IMG_DESTINATIONS: $PROJECTNAME:latest
     IMG_SIGNING: "false"
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,11 @@
+---
 image: registry.ddbuild.io/images/mirror/golang:1.19-bullseye
 variables:
   GO111MODULE: "on"
   PROJECTNAME: "watermarkpodautoscaler"
   GOPATH: "$CI_PROJECT_DIR/.cache"
   TARGET_TAG: v$CI_PIPELINE_ID-$CI_COMMIT_SHORT_SHA
-  BUILD_DOCKER_REGISTRY: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci"
+  BUILD_DOCKER_REGISTRY: "registry.ddbuild.io/ci"
   JOB_DOCKER_IMAGE: "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-containers-project:v2.0.0"
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
@@ -12,7 +13,7 @@ variables:
 cache: &global_cache
   key: ${CI_COMMIT_REF_SLUG}
   paths:
-  - .cache
+    - .cache
   policy: pull-push
 
 stages:
@@ -27,54 +28,46 @@ before_script:
 
 build:
   stage: build
-  tags: [ "runner:main", "size:large" ]
+  tags: ["runner:main", "size:large"]
   script:
-  - make build
+    - make build
 
 tests:
   stage: test
-  tags: [ "runner:main", "size:large" ]
+  tags: ["runner:main", "size:large"]
   script:
-  - make test
+    - make test
 
 generate_code:
   stage: test
-  tags: [ "runner:main", "size:large" ]
+  tags: ["runner:main", "size:large"]
   script:
-  - make generate
-  - git diff --exit-code
+    - make generate
+    - git diff --exit-code
 
 build_image_amd64:
   stage: image
-  tags: ["runner:docker", "size:large"]
+  tags:
+    - "arch:amd64"
   image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: amd64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-amd64
-  before_script:
-    # DockerHub login for build to limit rate limit when pulling base images
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.watermarkpodautoscaler.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.watermarkpodautoscaler.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
-    - IMG=$TARGET_IMAGE make docker-build-ci docker-push
-    - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
+    - IMG=$TARGET_IMAGE make docker-buildx-ci
 
 build_image_arm64:
   stage: image
-  tags: ["runner:docker-arm", "platform:arm64"]
+  tags:
+    - "arch:arm64"
   image: $JOB_DOCKER_IMAGE
   variables:
     GOARCH: arm64
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-arm64
-  before_script:
-    # DockerHub login for build to limit rate limit when pulling base images
-    - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.watermarkpodautoscaler.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.watermarkpodautoscaler.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
   script:
-    - IMG=$TARGET_IMAGE make docker-build-ci docker-push
-    - if [ -n "$CI_COMMIT_TAG" ]; then docker tag $TARGET_IMAGE $RELEASE_IMAGE && docker push $RELEASE_IMAGE; fi
+    - IMG=$TARGET_IMAGE make docker-buildx-ci
 
 publish_public_main:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -111,7 +111,7 @@ trigger_internal_image:
     branch: master
     strategy: depend
   variables:
-    IMAGE_VERSION: tmpl-v1
+    IMAGE_VERSION: tmpl-v2
     IMAGE_NAME: $PROJECTNAME
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ CHANNELS=alpha
 DEFAULT_CHANNEL=alpha
 GOARCH?=amd64
 IMG_NAME=gcr.io/datadoghq/watermarkpodautoscaler
+RELEASE_IMAGE_TAG := $(if $(CI_COMMIT_TAG),--tag $(RELEASE_IMAGE),)
 
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
@@ -119,6 +120,8 @@ docker-build-ci:
 docker-push:
 	docker push ${IMG}
 
+docker-buildx-ci:
+	docker buildx build . --build-arg LDFLAGS="${LDFLAGS}" --platform=linux/${GOARCH} --label target=build --push --tag ${IMG} ${RELEASE_IMAGE_TAG}
 
 ##@ Tools
 CONTROLLER_GEN = bin/$(PLATFORM)/controller-gen

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ docker-push:
 	docker push ${IMG}
 
 docker-buildx-ci:
-	docker buildx build . --build-arg LDFLAGS="${LDFLAGS}" --platform=linux/${GOARCH} --label target=build --push --tag ${IMG} ${RELEASE_IMAGE_TAG}
+	docker buildx build . --build-arg LDFLAGS="${LDFLAGS}" --platform=linux/arm64,linux/amd64 --label target=build --push --tag ${IMG} ${RELEASE_IMAGE_TAG}
 
 ##@ Tools
 CONTROLLER_GEN = bin/$(PLATFORM)/controller-gen


### PR DESCRIPTION
### What does this PR do?

Use the `registry.ddbuild.io` registry instead of directly the internal ECR.
Update the makefile to use buildx now.

### Motivation

Migrate to more recent gitlab docker runner

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
