### PR TITLE
fix: remove temporary gitlab cache to fix ci build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,10 +8,6 @@ variables:
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
-cache: &global_cache
-  key: ${CI_COMMIT_REF_SLUG}
-  paths:
-    - /go/pkg/mod
 
 stages:
   - build


### PR DESCRIPTION
### What does this PR do?

On `main` the build failed on gitlabci only.
It seems to be due to a corruption on the cache using in gitlab to optimise the ci jobs. 

this PR attempt to fix the ci build by removing the usage of the cache.

### Motivation

Fix CI to be able to release a version of WPA controller

### Additional Notes

I suppose that the cache is corrupted because some jobs are using golang 1.22 and other 1.23 (with `ci-containers-project:v3.0.0` image). 
I'm working on a new `ci-containers-project` image that use golang 1.22 to do other tests and put back the CI cache.

we can see that the build job is working on this branch https://gitlab.ddbuild.io/DataDog/watermarkpodautoscaler/-/jobs/721815005

### Describe your test plan

Write there any instructions and details you may have to test your PR.
