### PR TITLE
recommenders: attach the current cluster name

### DIFF
--- a/controllers/datadoghq/recommender.go
+++ b/controllers/datadoghq/recommender.go
@@ -45,6 +45,7 @@ type RecommenderClientImpl struct {
 type ReplicaRecommendationRequest struct {
 	Namespace            string
 	TargetRef            *v1alpha1.CrossVersionObjectReference
+	TargetCluster        string
 	Recommender          *v1alpha1.RecommenderSpec
 	DesiredReplicas      int32
 	CurrentReplicas      int32
@@ -199,6 +200,7 @@ func buildWorkloadRecommendationRequest(request *ReplicaRecommendationRequest) (
 			Name:       request.TargetRef.Name,
 			ApiVersion: request.TargetRef.APIVersion,
 			Namespace:  request.Namespace,
+			Cluster:    request.TargetCluster,
 		},
 		Constraints: &autoscaling.WorkloadRecommendationConstraints{
 			MinReplicas: request.MinReplicas,

--- a/controllers/datadoghq/replica_calculator.go
+++ b/controllers/datadoghq/replica_calculator.go
@@ -67,14 +67,16 @@ type ReplicaCalculator struct {
 	metricsClient     metricsclient.MetricsClient
 	recommenderClient RecommenderClient
 	podLister         corelisters.PodLister
+	k8sClusterName    string
 }
 
 // NewReplicaCalculator returns a ReplicaCalculator object reference
-func NewReplicaCalculator(metricsClient metricsclient.MetricsClient, recommenderClient RecommenderClient, podLister corelisters.PodLister) *ReplicaCalculator {
+func NewReplicaCalculator(metricsClient metricsclient.MetricsClient, recommenderClient RecommenderClient, podLister corelisters.PodLister, k8sClusterName string) *ReplicaCalculator {
 	return &ReplicaCalculator{
 		metricsClient:     metricsClient,
 		recommenderClient: recommenderClient,
 		podLister:         podLister,
+		k8sClusterName:    k8sClusterName,
 	}
 }
 
@@ -280,6 +282,7 @@ func (c *ReplicaCalculator) GetRecommenderReplicas(logger logr.Logger, target *a
 	var request = ReplicaRecommendationRequest{
 		Namespace:            wpa.Namespace,
 		TargetRef:            &wpa.Spec.ScaleTargetRef,
+		TargetCluster:        c.k8sClusterName,
 		Recommender:          wpa.Spec.Recommender,
 		CurrentReadyReplicas: currentReadyReplicas,
 		CurrentReplicas:      target.Status.Replicas,

--- a/controllers/datadoghq/replica_calculator_test.go
+++ b/controllers/datadoghq/replica_calculator_test.go
@@ -253,7 +253,7 @@ func (tc *replicaCalcTestCase) runTest(t *testing.T) {
 	mClient := metrics.NewRESTMetricsClient(rClient.MetricsV1beta1(), nil, emClient)
 	recoClient := NewMockRecommenderClient()
 
-	replicaCalculator := NewReplicaCalculator(mClient, recoClient, informer.Lister())
+	replicaCalculator := NewReplicaCalculator(mClient, recoClient, informer.Lister(), "test-cluster")
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -3017,7 +3017,7 @@ func TestGetReadyPodsCount(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
 			informer := informerFactory.Core().V1().Pods()
 
-			replicaCalculator := NewReplicaCalculator(nil, nil, informer.Lister())
+			replicaCalculator := NewReplicaCalculator(nil, nil, informer.Lister(), "test-cluster")
 
 			stop := make(chan struct{})
 			defer close(stop)


### PR DESCRIPTION
### What does this PR do?

The recommender needs to advertise the current cluster name in the request.

### Motivation

This is required to have a fully qualified kubernetes target ref in multi-cluster environments.

### Additional Notes

The cluster is optional as it's only needed in setups using the recommender and multiple k8s clusters.