### PR TITLE
Fix recommender API low/high watermark handling when < 1

### DIFF
--- a/controllers/datadoghq/recommender.go
+++ b/controllers/datadoghq/recommender.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	autoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
+
 	"github.com/DataDog/watermarkpodautoscaler/apis/datadoghq/v1alpha1"
 )
 
@@ -177,10 +178,10 @@ func buildWorkloadRecommendationRequest(request *ReplicaRecommendationRequest) (
 	}
 	upperBound, lowerBound := float64(0), float64(0)
 	if reco.HighWatermark != nil {
-		upperBound = float64(reco.HighWatermark.MilliValue() / 1000.)
+		upperBound = float64(reco.HighWatermark.MilliValue()) / 1000.0
 	}
 	if reco.LowWatermark != nil {
-		lowerBound = float64(reco.LowWatermark.MilliValue() / 1000.)
+		lowerBound = float64(reco.LowWatermark.MilliValue()) / 1000.0
 	}
 	target := &autoscaling.WorkloadRecommendationTarget{
 		Type:        request.Recommender.TargetType,


### PR DESCRIPTION
### What does this PR do?

This fixes the WorkloadRecommendationRequest target to have correct `UpperBound` and `LowerBound` values (float64) when the incoming RecommenderSpec has lower than 1.0 low or high watermarks.

### Motivation

It wasn't possible to have:
```
apiVersion: datadoghq.com/v1alpha1
kind: WatermarkPodAutoscaler
metadata:
  name: koutris-storage-metrics-intake-az0
  namespace: koutris
spec:
   ...
   recommender:
    highWatermark: "0.8"
    lowWatermark: "0.4"
    settings:
      worker_group: koutris-storage-metrics-intake-az0
    targetType: memory
    url: https://shard-orchestrator-api.rapid-shard-orchestrator.all-clusters.local-dc.fabric.dog:8443/autoscaling/recommendation
   ...
```

The Recommender API request that was triggered was:
```
{
  "targetRef": {
    ...
  },
  ...
  "targets": [
    {
      "type": "memory"
    }
  ],
  "settings": {
    "worker_group": "koutris-storage-metrics-intake-az0"
  }
}
```

As seen above there's no `lowWatermark`, `highWatermark` fields (because they're omitted when 0).

### Additional Notes


### Describe your test plan

Deploy and check that it works :)
