### PR TITLE
recommender: propagate the observed value to the status

### DIFF
--- a/controllers/datadoghq/recommender.go
+++ b/controllers/datadoghq/recommender.go
@@ -56,11 +56,12 @@ type ReplicaRecommendationRequest struct {
 }
 
 type ReplicaRecommendationResponse struct {
-	Replicas           int
-	ReplicasLowerBound int
-	ReplicasUpperBound int
-	Timestamp          time.Time
-	Details            string
+	Replicas            int
+	ReplicasLowerBound  int
+	ReplicasUpperBound  int
+	Timestamp           time.Time
+	Details             string
+	ObservedTargetValue float64
 }
 
 // NewRecommenderClient returns a new RecommenderClient with the given http.Client.
@@ -231,6 +232,11 @@ func buildReplicaRecommendationResponse(reply *autoscaling.WorkloadRecommendatio
 		ReplicasUpperBound: int(reply.GetUpperBoundReplicas()),
 		Timestamp:          reply.GetTimestamp().AsTime(),
 		Details:            reply.GetReason(),
+	}
+	// We expect a single target (since we support a single targets in the request)
+	// If we have it we can extract the observed target value
+	if reply.GetObservedTargets() != nil && len(reply.GetObservedTargets()) == 1 {
+		ret.ObservedTargetValue = reply.GetObservedTargets()[0].GetTargetValue()
 	}
 	return ret, nil
 }

--- a/controllers/datadoghq/recommender_test.go
+++ b/controllers/datadoghq/recommender_test.go
@@ -11,17 +11,18 @@ import (
 	"testing"
 	"time"
 
-	autoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	autoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
 
 	"github.com/DataDog/watermarkpodautoscaler/apis/datadoghq/v1alpha1"
 )
 
 func NewMockRecommenderClient() *RecommenderClientMock {
 	return &RecommenderClientMock{
-		ReplicaRecommendationResponse{2, 1, 3, time.Now(), "because"},
+		ReplicaRecommendationResponse{2, 1, 3, time.Now(), "because", 0.5},
 		nil,
 	}
 }

--- a/controllers/datadoghq/replica_calculator.go
+++ b/controllers/datadoghq/replica_calculator.go
@@ -321,8 +321,6 @@ func (c *ReplicaCalculator) GetRecommenderReplicas(logger logr.Logger, target *a
 		return ReplicaCalculation{currentReadyReplicas, 0, reco.Timestamp, currentReadyReplicas, metricPosition{false, false}}, nil
 	}
 
-	// utilization is used to propagate the observed utilization to the HPA (and related metrics). Since we don't have a real utilization (the recommender
-	// doesn't provide it), we need to compute it from the recommendation. FIXME
 	utilizationQuantity := int64(reco.ObservedTargetValue * 1000) // We need to multiply by 1000 to convert it to milliValue
 	replicaCount, metricPos := adjustReplicaCount(logger, target.Status.Replicas, currentReadyReplicas, wpa, metricName, int32(reco.Replicas), int32(reco.ReplicasLowerBound), int32(reco.ReplicasUpperBound))
 	logger.Info("Replicas Recommender replica calculation", "metricName", metricName, "replicaCount", replicaCount, "utilizationQuantity", utilizationQuantity, "timestamp", reco.Timestamp, "currentReadyReplicas", currentReadyReplicas)

--- a/controllers/datadoghq/replica_calculator.go
+++ b/controllers/datadoghq/replica_calculator.go
@@ -323,10 +323,10 @@ func (c *ReplicaCalculator) GetRecommenderReplicas(logger logr.Logger, target *a
 
 	// utilization is used to propagate the observed utilization to the HPA (and related metrics). Since we don't have a real utilization (the recommender
 	// doesn't provide it), we need to compute it from the recommendation. FIXME
-	utilization := int64(reco.ObservedTargetValue * 1000) // We need to multiply by 1000 to convert it to milliValue
+	utilizationQuantity := int64(reco.ObservedTargetValue * 1000) // We need to multiply by 1000 to convert it to milliValue
 	replicaCount, metricPos := adjustReplicaCount(logger, target.Status.Replicas, currentReadyReplicas, wpa, metricName, int32(reco.Replicas), int32(reco.ReplicasLowerBound), int32(reco.ReplicasUpperBound))
 	logger.Info("Replicas Recommender replica calculation", "metricName", metricName, "replicaCount", replicaCount, "utilizationQuantity", utilizationQuantity, "timestamp", reco.Timestamp, "currentReadyReplicas", currentReadyReplicas)
-	return ReplicaCalculation{replicaCount, utilization, reco.Timestamp, currentReadyReplicas, metricPos}, nil
+	return ReplicaCalculation{replicaCount, utilizationQuantity, reco.Timestamp, currentReadyReplicas, metricPos}, nil
 }
 
 func getReplicaCountUpscale(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, adjustedUsage float64, highMark *resource.Quantity) (replicaCount int32) {

--- a/controllers/datadoghq/watermarkpodautoscaler_controller.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller.go
@@ -774,7 +774,7 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasWithRecommender(logger
 		Type: autoscalingv2.ResourceMetricSourceType,
 		Resource: &autoscalingv2.ResourceMetricStatus{
 			Name:                corev1.ResourceName(recommenderName),
-			CurrentAverageValue: *resource.NewMilliQuantity(int64(replicaCalculation.replicaCount), resource.DecimalSI),
+			CurrentAverageValue: *resource.NewMilliQuantity(replicaCalculation.utilization, resource.DecimalSI),
 		},
 	}
 


### PR DESCRIPTION
This makes sure we get the proper value for the `metric` field and metrics in the WPA (before this change the replica count was used instead)
