### PR TITLE
Update example chart with new CRD definitions

### DIFF
--- a/chart/watermarkpodautoscaler/CHANGELOG.md
+++ b/chart/watermarkpodautoscaler/CHANGELOG.md
@@ -1,5 +1,9 @@
 # WatermarkPodAutoscaler Helm chart changelog
 
+## v0.5.1
+
+* CustomResourceDefinition update to fix display of high/low watermarks in some specific cases
+
 ## v0.5
 
 > [!IMPORTANT]

--- a/chart/watermarkpodautoscaler/Chart.yaml
+++ b/chart/watermarkpodautoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.9.0-rc.1
 description: Watermark Pod Autoscaler
 name: watermarkpodautoscaler
-version: v0.5.0
+version: v0.5.1
 dependencies:
   - name: datadog-crds
     version: "=1.3.0"

--- a/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd_v1.yaml
+++ b/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd_v1.yaml
@@ -30,10 +30,10 @@ spec:
     - jsonPath: .status.currentMetrics[*].external.currentValue..
       name: value
       type: string
-    - jsonPath: .spec.metrics[*].external.highWatermark..
+    - jsonPath: .spec..highWatermark
       name: high watermark
       type: string
-    - jsonPath: .spec.metrics[*].external.lowWatermark..
+    - jsonPath: .spec..lowWatermark
       name: low watermark
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd_v1beta1.yaml
+++ b/chart/watermarkpodautoscaler/templates/datadoghq.com_watermarkpodautoscalers_crd_v1beta1.yaml
@@ -20,10 +20,10 @@ spec:
   - JSONPath: .status.currentMetrics[*].external.currentValue..
     name: value
     type: string
-  - JSONPath: .spec.metrics[*].external.highWatermark..
+  - JSONPath: .spec..highWatermark
     name: high watermark
     type: string
-  - JSONPath: .spec.metrics[*].external.lowWatermark..
+  - JSONPath: .spec..lowWatermark
     name: low watermark
     type: string
   - JSONPath: .metadata.creationTimestamp


### PR DESCRIPTION
### What does this PR do?

This also fixes the CRD that are in the chart.

### Motivation

In commit cd5a4925, I forgot to update the alongside chart provided with WPA.

### Additional Notes

It's not clear if this is needed because the chart depends on datadog CRD which I have no idea how they are built.
Also not clear if the chart version needs to be bumped (there's a discrepancy between the changelog and the chart version.

### Describe your test plan

This was tested by modifying directly the CRD in an experimental cluster.
