### PR TITLE
Bump WPA chart version to v0.5.0

### DIFF
--- a/chart/watermarkpodautoscaler/Chart.yaml
+++ b/chart/watermarkpodautoscaler/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v0.9.0-rc.1
 description: Watermark Pod Autoscaler
 name: watermarkpodautoscaler
-version: v0.4.0
+version: v0.5.0
 dependencies:
   - name: datadog-crds
     version: "=1.3.0"


### PR DESCRIPTION
### What does this PR do?

Bump WPA chart version to v0.5.0 for the changes added in https://github.com/DataDog/watermarkpodautoscaler/pull/221.

### Motivation

Reconcile Chart version and Changelog version discrepency. 

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
