### PR TITLE
Fix lower/upper bound inversion in recommender replica calculation

### DIFF
--- a/controllers/datadoghq/replica_calculator.go
+++ b/controllers/datadoghq/replica_calculator.go
@@ -476,7 +476,7 @@ func getReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas i
 	return replicaCount, utilizationQuantity.MilliValue(), position
 }
 
-func adjustReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, recommendedReplicaCount, upperBoundReplicas, lowerBoundReplicas int32) (replicaCount int32, position metricPosition) {
+func adjustReplicaCount(logger logr.Logger, currentReplicas, currentReadyReplicas int32, wpa *v1alpha1.WatermarkPodAutoscaler, recommendedReplicaCount, lowerBoundReplicas, upperBoundReplicas int32) (replicaCount int32, position metricPosition) {
 	labelsWithReason := prometheus.Labels{wpaNamePromLabel: wpa.Name, wpaNamespacePromLabel: wpa.Namespace, resourceNamespacePromLabel: wpa.Namespace, resourceNamePromLabel: wpa.Spec.ScaleTargetRef.Name, resourceKindPromLabel: wpa.Spec.ScaleTargetRef.Kind, reasonPromLabel: withinBoundsPromLabelVal}
 	msg := ""
 

--- a/controllers/datadoghq/replica_calculator_test.go
+++ b/controllers/datadoghq/replica_calculator_test.go
@@ -1841,6 +1841,26 @@ func TestReplicaCalcWithRecommender(t *testing.T) {
 				Details:            "Fake",
 			},
 		},
+		// toward downscale but within bounds should not have isAbove/isBelow all true
+		{
+			expectedReplicas: 31,
+			readyReplicas:    40,
+			timestamp:        ts,
+			pos: metricPosition{
+				isAbove: false,
+				isBelow: false,
+			},
+			details: "Fake",
+			scale:   makeScale(testDeploymentName, 40, map[string]string{"name": "test-pod"}),
+			wpa:     wpa,
+			recommenderResponse: &ReplicaRecommendationResponse{
+				Replicas:           31,
+				ReplicasLowerBound: 27,
+				ReplicasUpperBound: 53,
+				Timestamp:          ts,
+				Details:            "Fake",
+			},
+		},
 	}
 	for i, tc := range tcs {
 		t.Run(fmt.Sprintf("test-%d", i), tc.runTest)


### PR DESCRIPTION
### What does this PR do?

It fixes a bug where the recommender `upperReplicas` and `lowerReplicas` were reversed when calling `adjustReplicaCount`.

### Motivation

With the lower and upper bound reversed it would prevent some downscale (and possibly upscale) scenarios to happen, because the returned `metricPosition` would have both `isAbove=true` and `isBelow=true`. This in turn would confuse the rest of the algorithm, especially the component that tried to converge toward one of the watermark.

### Additional Notes



### Describe your test plan

It's hard to test, but the fix is very simple.

It was spot because of this log parameters that show the reverse:
<img width="419" alt="image" src="https://github.com/user-attachments/assets/775d364d-54a2-4db9-9b5d-9439a6c3c964" />

In that example, the deployment was at 40 pods which was within bounds but in the higher part of the bounds and WPA wasn't trying to downscale producing this error:
```
Scaling down would likely make the usage go above the High Watermark
```
which didn't make sense with the parameters returned by the recommender.


