### PR TITLE
Fix release github worflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       # https://github.com/marketplace/actions/goreleaser-action
       contents: write
-      # actions/upload-artifact@v3
+      # actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       actions: write
     steps:
       - name: Checkout
@@ -50,7 +50,7 @@ jobs:
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: kubectl-wpa-linux
           path: |
@@ -63,7 +63,7 @@ jobs:
     permissions:
       # https://github.com/marketplace/actions/goreleaser-action
       contents: write
-      # actions/upload-artifact@v3
+      # actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       actions: write
     steps:
       - uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: kubectl-wpa-darwin
           path: |
@@ -102,7 +102,7 @@ jobs:
     permissions:
       # https://github.com/marketplace/actions/goreleaser-action
       contents: write
-      # actions/upload-artifact@v3
+      # actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       actions: write
     steps:
       - uses: actions/checkout@v3
@@ -129,7 +129,7 @@ jobs:
         env:
           GORELEASER_PREVIOUS_TAG: ${{steps.latest_version.outputs.release}}
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: kubectl-wpa-windows
           path: |
@@ -143,7 +143,7 @@ jobs:
       # https://github.com/marketplace/actions/goreleaser-action
       # https://github.com/softprops/action-gh-release?tab=readme-ov-file#permissions 
       contents: write
-      # actions/download-artifact@v3
+      # actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       actions: read
       # rajatjindal/krew-release-bot@v0.0.43
       pull-requests: write
@@ -158,17 +158,17 @@ jobs:
           mkdir -p ./dist/darwin
           mkdir -p ./dist/windows
       - name: Download linux binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: kubectl-wpa-linux
           path: ./tmp-build/linux
       - name: Download darwin binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: kubectl-wpa-darwin
           path: ./tmp-build/darwin
       - name: Download windows binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: kubectl-wpa-windows
           path: ./tmp-build/windows


### PR DESCRIPTION
### What does this PR do?

update 2 deprecated github actions:
- upload-artifact from v3 to v4
- download-artifact from v3 to v4

### Motivation

fix release process to finalise v0.9.0 release
error info: https://github.com/DataDog/watermarkpodautoscaler/actions/runs/12936581622 

### Additional Notes

Official communication https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/ 

### Describe your test plan

Write there any instructions and details you may have to test your PR.
