### PR TITLE
Fix Evicted Pods Skewing Available Replicas Calculation

### DIFF
--- a/controllers/datadoghq/replica_calculator.go
+++ b/controllers/datadoghq/replica_calculator.go
@@ -113,7 +113,6 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(logger logr.Logger, target
 	}
 
 	ratioReadyPods := (100 * currentReadyReplicas / (int32(len(podList)) - incorrectTargetPodsCount))
-
 	if ratioReadyPods < wpa.Spec.MinAvailableReplicaPercentage {
 		return ReplicaCalculation{}, fmt.Errorf("%d %% of the pods are unready, will not autoscale %s/%s", ratioReadyPods, target.Namespace, target.Name)
 	}

--- a/controllers/datadoghq/replica_calculator_test.go
+++ b/controllers/datadoghq/replica_calculator_test.go
@@ -1964,6 +1964,48 @@ func TestTooManyUnreadyPods(t *testing.T) {
 	tc.runTest(t)
 }
 
+// We have evicted pods that should not be counted when evaluating the MinAverageReplicaPercentage
+// Previously, evicted pods were incorrectly included in the ready pods calculation which could prevent scaling
+// This test makes sure that an evicted pod does not prevent the WPA from scaling up
+func TestMinAverageReplicaPercentageIgnoresEvictedPods(t *testing.T) {
+	logf.SetLogger(zap.New())
+	metric1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ExternalMetricSourceType,
+		External: &v1alpha1.ExternalMetricSource{
+			MetricName:     "loadbalancer.request.per.seconds",
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+			HighWatermark:  resource.NewMilliQuantity(10000, resource.DecimalSI),
+			LowWatermark:   resource.NewMilliQuantity(7000, resource.DecimalSI),
+		},
+	}
+
+	tc := replicaCalcTestCase{
+		expectedReplicas: 3,
+		readyReplicas:    1,
+		pos: metricPosition{
+			isAbove: true,
+			isBelow: false,
+		},
+		scale: makeScale(testDeploymentName, 2, map[string]string{"name": "test-pod"}),
+		wpa: &v1alpha1.WatermarkPodAutoscaler{
+			Spec: v1alpha1.WatermarkPodAutoscalerSpec{
+				Algorithm:                     "average",
+				MinAvailableReplicaPercentage: 51, // must use 51 because ratioReady calculation is exclusive
+				Tolerance:                     *resource.NewMilliQuantity(20, resource.DecimalSI),
+				Metrics:                       []v1alpha1.MetricSpec{metric1},
+				ReplicaScalingAbsoluteModulo:  v1alpha1.NewInt32(1),
+			},
+		},
+		podPhase: []corev1.PodPhase{corev1.PodRunning, corev1.PodFailed}, // simulate a pod eviction
+		metric: &metricInfo{
+			spec:                metric1,
+			levels:              []int64{30000},
+			expectedUtilization: 30000, // only 1 ready replica so it's 100% utilized
+		},
+	}
+	tc.runTest(t)
+}
+
 // We have pods that are pending and one is within an acceptable window.
 func TestPendingNotExpiredScale(t *testing.T) {
 	logf.SetLogger(zap.New())


### PR DESCRIPTION
### What does this PR do?

The PR fixes a bug related to the `minAvailableReplicaPercentage` option and evicted pods.

> **minAvailableReplicaPercentage:** Indicates the minimum percentage of replicas that need to be available in order for the controller to autoscale the target. For instance, if set at 50 and less than half of the pods behind the target are in an Available state, the target will not be scaled by the controller.

#### Background
According to the [Kubernetes Documention](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/)
> During a node-pressure eviction, the kubelet sets the [phase](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) for the selected pods to Failed, and terminates the Pod. 

Because evicted pods remain in the `Terminated` state until garbage collected, they were skewing the `minAvailableReplicaPercentage` calculation because the WPA considers any pod that's been Ready at least once to be part of its target. 

#### Example
```
NAME                                                    READY   STATUS    RESTARTS   AGE
nginx-7b87cc957f-2ws2p                                  0/2     Error     1          37m
nginx-7b87cc957f-4cxmq                                  2/2     Running   0          57s
```
Given the above scenario, previously, the available replica percentage would have been `50%`. Now, with the `Failed` pod phase filter in place, it would be `100%`.
  
### Motivation

A bug report.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan
I first tried simulating evictions by calling the eviction API, but the evicted pods were not persisting as expected. Upon closer inspection of the documentation I learned:
> Node-pressure eviction is not the same as [API-initiated eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/api-eviction/).

From there, I moved on to simulating a `Node-pressure` eviction.

#### Step 1: Deploy Cluster With Limited Resources
I deployed a `k3s` cluster with the following command:
```
k3d cluster create \
  --agents 2 \
  --agents-memory 3g \
  --k3s-arg "--disable=traefik@server:0" \
  --k3s-arg "--kubelet-arg=eviction-hard=memory.available<1Gi@agent:0" \
  --k3s-arg "--kubelet-arg=eviction-hard=memory.available<1Gi@agent:1" \
  --k3s-node-label "role=worker@agent:0,1" 
```
The included flags translate to:
* Deploy 2 "agent" (i.e. worker) nodes
* Agent nodes have 3Gi of memory, overridden from using all of the memory allocated to docker on my local machine
* Both agent nodes' kubelets enforce a hard 1Gi of available memory, and will evict pods that infringe on that
* Agent nodes are tagged with `role=worker`

#### Step 2: Force Memory Consumption
With a low bar for memory eviction in place, I needed a way for my deployed pods to consume enough memory to trigger an eviction. I looked into using `stress-ng` but I wasn't able to find a way to gradually increase memory usage. Ultimately I settled on a small Go program that allocates memory in a loop below.

<details>
<summary>go.mod</summary>
<br>

```
module memory-eater

go 1.23
```
</details>

<details>
<summary>main.go</summary>
<br>

```
package main

    import (
      "fmt"
      "runtime"
      "runtime/debug"
      "time"
    )

    func main() {
      // turn off garbage collection
      debug.SetGCPercent(-1)

      var memUsage []byte

      // allocate 5MB chunks
      allocSize := 5 * 1024 * 1024 

      fmt.Println("Starting memory consumption...")

      for i := 1; ; i++ {
        block := make([]byte, allocSize)
        for j := range block {
          block[j] = 1 // Actively write to memory to keep the memory in use
        }
        memUsage = append(memUsage, block...)

        memStats := &runtime.MemStats{}
        runtime.ReadMemStats(memStats)
        fmt.Printf("Iteration: %d | Allocated Memory: %.2f MB\n", i, float64(memStats.Alloc)/1024/1024)

        time.Sleep(1 * time.Second)
      }
    }

```
</details>

#### Step 3: Deploy a WPA Scalable Deployment
I deployed a basic Nginx deployment with a few key modifications
1. A taint toleration, so pods can still be scheduled after the node experiences memory pressure
    ```
    tolerations:
      - key: "node.kubernetes.io/memory-pressure"
        operator: "Exists"
        effect: "NoSchedule"
    ```
2. A node selector to target the agent nodes
    ```
    nodeSelector:
        role: worker
    ```
3. A sidecar container with the memory-eater application mounted
    ```
    - name: memory-eater
      image: golang:1.23
      imagePullPolicy: Always
      workingDir: /usr/src/memory-eater
      command: ["/bin/sh", "-c", "sleep infinity"]
      volumeMounts:
        - name: go-program
          mountPath: /usr/src/memory-eater
    ```

#### Step 4: Deploy/Configure the WPA
Deploy the WPA with the `minAvailableReplicaPercentage` option 

```
apiVersion: datadoghq.com/v1alpha1
kind: WatermarkPodAutoscaler
metadata:
  name: nginx
spec:
  algorithm: average
  minReplicas: 3
  maxReplicas: 30
  tolerance: "0.0"
  minAvailableReplicaPercentage: 50 # <--This is key to the test
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: nginx
  metrics:
  - type: External
    external:
      highWatermark: 9
      lowWatermark: 8
      metricName: datadogmetric@<NAMESPACE>:nginx
      metricSelector: {}
```

#### Step 5: Trigger evictions
Trigger enough evictions so that evicted pods outnumber ready pods by running the following command N times:
```
# Issue an exec command without in the background, without tailing the logs
kubectl exec <POD> -c memory-eater -n <NAMESPACE> -- nohup go run . >/dev/null 2>&1 &
```

#### Step 6: Generate Load
I port-forwarded to my Nginx service

```
kubectl port-forward service/nginx -n workload-nginx 8080:80
```

Then I used k6 to generate a constant amount of load to trigger a desired scale-up

```
import http from 'k6/http';
import { check } from 'k6';

export let options = {
  scenarios: {
    fixed_rps: {
      executor: 'constant-arrival-rate',
      rate: 50, 
      timeUnit: '1s',
      duration: '30m',
      preAllocatedVUs: 100,
      maxVUs: 200,
    }
  }
};

export default function () {
  const res = http.get('http://localhost:8080');
  check(res, { 'status was 200': (r) => r.status == 200 }); // probably unnecessary
}
```

#### Step 7: Observe The Difference Between WPA Versions
##### Old Behavior- stuck, unable to scale while evicted pods skew available replica calculation
![WPA Failure Behavior](https://github.com/user-attachments/assets/f69d7438-e639-4d83-855a-7f1bfd3d0814)

##### New Behavior- able to scale despite the evicted pods persisting
![WPA Fix Behavior](https://github.com/user-attachments/assets/7a69d8aa-c527-4a01-802e-2e317fa20258)

