### PR TITLE
Fix two panics

### DIFF
--- a/controllers/datadoghq/replica_calculator.go
+++ b/controllers/datadoghq/replica_calculator.go
@@ -397,8 +397,16 @@ func tryToConvergeToWatermarkForUsage(logger logr.Logger, convergingType v1alpha
 	maxReplicas := wpa.Spec.MaxReplicas
 
 	var lowerBoundReplicaCount, upperBoundReplicaCount int32
-	lowerBoundReplicaCount = math32.Cap(math32.Ceil(float64(currentReadyReplicas)/float64(highMark.MilliValue())*adjustedUsage), minReplicas, maxReplicas)
-	upperBoundReplicaCount = math32.Cap(math32.Floor(float64(currentReadyReplicas)/float64(lowMark.MilliValue())*adjustedUsage), minReplicas, maxReplicas)
+	if highMark.MilliValue() == 0 {
+		lowerBoundReplicaCount = currentReplicas
+	} else {
+		lowerBoundReplicaCount = math32.Cap(math32.Ceil(float64(currentReadyReplicas)/float64(highMark.MilliValue())*adjustedUsage), minReplicas, maxReplicas)
+	}
+	if lowMark.MilliValue() == 0 {
+		upperBoundReplicaCount = currentReplicas
+	} else {
+		upperBoundReplicaCount = math32.Cap(math32.Floor(float64(currentReadyReplicas)/float64(lowMark.MilliValue())*adjustedUsage), minReplicas, maxReplicas)
+	}
 	return tryToConvergeToWatermark(logger, convergingType, currentReplicas, currentReadyReplicas, wpa, lowerBoundReplicaCount, upperBoundReplicaCount)
 }
 

--- a/controllers/datadoghq/watermarkpodautoscaler_controller.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller.go
@@ -287,8 +287,9 @@ func (r *WatermarkPodAutoscalerReconciler) Reconcile(ctx context.Context, reques
 		setCondition(instance, autoscalingv2.AbleToScale, corev1.ConditionFalse, datadoghqv1alpha1.ReasonFailedProcessWPA, "Error happened while processing the WPA")
 		// In case of `reconcileWPA` error, we need to requeue the Resource in order to retry to process it again
 		// we put a delay in order to not retry directly and limit the number of retries if it only a transient issue.
-		if err = r.updateStatusIfNeeded(ctx, wpaStatusOriginal, instance); err != nil {
-			r.eventRecorder.Event(instance, corev1.EventTypeWarning, datadoghqv1alpha1.ReasonFailedUpdateStatus, err.Error())
+		if err2 := r.updateStatusIfNeeded(ctx, wpaStatusOriginal, instance); err2 != nil {
+			err = utilerrors.NewAggregate([]error{err, err2})
+			r.eventRecorder.Event(instance, corev1.EventTypeWarning, datadoghqv1alpha1.ReasonFailedUpdateStatus, err2.Error())
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{RequeueAfter: requeueAfterForWPAErrors(err)}, nil


### PR DESCRIPTION
### What does this PR do?

- err can be nil when `requeueAfterForWPAErrors` is called
- low/high watermakrs can be 0

### Motivation

We found a panic in our test env
