### PR TITLE
fix(releasing): use github token for getting the last release tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,6 +120,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           owner: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repo: watermarkpodautoscaler
           excludes: prerelease, draft
       - name: Build


### PR DESCRIPTION
### What does this PR do?

Use GITHUB_TOKEN for getting last release version in the github action release workflow.

### Motivation

the goal is to avoid rate limit during releasing like this occurence: https://github.com/DataDog/watermarkpodautoscaler/actions/runs/13819715791/job/38661833976

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
