### PR TITLE
Add Gitlab job for building FIPS enabled image for GovCloud

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,8 +148,8 @@ trigger_internal_image_fips:
   variables:
     IMAGE_VERSION: tmpl-v3-fips
     IMAGE_NAME: $PROJECTNAME
-    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
-    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-fips
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}-fips
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,3 +135,21 @@ trigger_internal_image:
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"
+
+trigger_internal_image_fips:
+  stage: release
+  rules:
+    - if: $CI_COMMIT_TAG
+    - when: never
+  trigger:
+    project: DataDog/images
+    branch: master
+    strategy: depend
+  variables:
+    IMAGE_VERSION: tmpl-v3-fips
+    IMAGE_NAME: $PROJECTNAME
+    RELEASE_TAG: ${CI_COMMIT_REF_SLUG}
+    BUILD_TAG: ${CI_COMMIT_REF_SLUG}
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    RELEASE_STAGING: "true"
+    RELEASE_PROD: "true"


### PR DESCRIPTION
### What does this PR do?

Add a gitlab job to trigger fips enabled image

### Motivation

Same change as [this one](https://github.com/DataDog/extendeddaemonset/commit/e1e56cb179a2d4f1605967c8a1f6d6c299a57ef8) made to the extendeddaemonset

### Additional Notes

Relies on [this PR](https://github.com/DataDog/images/pull/6780)

### Describe your test plan

Write there any instructions and details you may have to test your PR.
