### PR TITLE
doc(README): Update docs to explain why you shouldn't set replicas in the deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ Will yield:
     No. If you define the replicas field in your Deployment spec, every time you apply the manifest, the replica count is reset to that specified value.
     For example, if you have replicas: 2 in your Deployment but the Watermark Pod Autoscaler (WPA) has scaled the Deployment up to 10 replicas, reapplying the manifest will revert the replica count to 2. This causes the Deployment to scale down immediately, and WPA must scale it back up again.
     To avoid conflicts between the Deployment controller and WPA over the desired replica count, omit the replicas field entirely. This allows WPA to manage scaling without interference.
+    Also see the [Kubernetes docs on migrating to HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling).
 
 #### RBAC
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,11 @@ Will yield:
 
     Yes, WPA can scale on multiple metrics and works similar to [HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#scaling-on-multiple-metrics). WPA evaluates each metric separately and proposes the number of replicas associated with the metric that requires the largest number. For example, if WPA evaluates metric1, metric2, metric3, and for each it calculates 10, 20, 30 replica proposals respectively, the final proposal is 30.
 
+- **Should I specify replicas in my Deployment manifest?**
+
+    No. If you define the replicas field in your Deployment spec, every time you apply the manifest, the replica count is reset to that specified value.
+    For example, if you have replicas: 2 in your Deployment but the Watermark Pod Autoscaler (WPA) has scaled the Deployment up to 10 replicas, reapplying the manifest will revert the replica count to 2. This causes the Deployment to scale down immediately, and WPA must scale it back up again.
+    To avoid conflicts between the Deployment controller and WPA over the desired replica count, omit the replicas field entirely. This allows WPA to manage scaling without interference.
 
 #### RBAC
 


### PR DESCRIPTION
### What does this PR do?

Add a note to the README explaining why you shouldn't set replicas in the deployment, and the issues you may see if you do.

### Motivation

If you set the `replicas` value on your deployment, then every time you apply the deployment, the number of replicas will be reset to that value. This will cause a race between the Kubernetes controller and WPA in setting the number of replicas and fluctuate the number down and up when you apply the deployment.

### Additional Notes

N/A

### Describe your test plan

N/A
