### PR TITLE
Generate fips image compiled with Go boringcrypto

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ variables:
   DOCKER_REGISTRY_LOGIN_SSM_KEY: docker_hub_login
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
+  FIPS_ENABLED: false
 cache: &global_cache
   key: ${CI_COMMIT_REF_SLUG}
   paths:
@@ -71,7 +72,14 @@ build_image:
     TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG
   script:
-    - IMG=$TARGET_IMAGE make docker-buildx-ci
+    - IMG=$TARGET_IMAGE FIPS_ENABLED=$FIPS_ENABLED make docker-buildx-ci
+
+build_image_fips:
+  extends: build_image
+  variables:
+    TARGET_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
+    RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips
+    FIPS_ENABLED: "true"
 
 publish_public_main:
   stage: release
@@ -150,6 +158,6 @@ trigger_internal_image_fips:
     IMAGE_NAME: $PROJECTNAME
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-fips
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-fips
-    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
+    TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips
     RELEASE_STAGING: "true"
     RELEASE_PROD: "true"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+#
+ARG FIPS_ENABLED=false
+
 # Build the manager binary
 FROM golang:1.22 as builder
 
@@ -29,7 +32,13 @@ COPY third_party/ third_party/
 # Build
 ARG LDFLAGS
 ARG GOARCH
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o manager main.go
+ARG FIPS_ENABLED
+RUN echo "FIPS_ENABLED is: $FIPS_ENABLED"
+RUN if [ "$FIPS_ENABLED" = "true" ]; then \
+      CGO_ENABLED=1 GOEXPERIMENT=boringcrypto GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -tags fips -a -ldflags "${LDFLAGS}" -o manager main.go; \
+    else \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -ldflags "${LDFLAGS}" -o manager main.go; \
+    fi
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ DEFAULT_CHANNEL=alpha
 GOARCH?=amd64
 IMG_NAME=gcr.io/datadoghq/watermarkpodautoscaler
 RELEASE_IMAGE_TAG := $(if $(CI_COMMIT_TAG),--tag $(RELEASE_IMAGE),)
+FIPS_ENABLED?=false
 
 CRD_OPTIONS ?= "crd"
 
@@ -114,14 +115,14 @@ generate: $(CONTROLLER_GEN) generate-openapi
 docker-build: generate docker-build-ci
 
 docker-build-ci:
-	docker build . -t ${IMG} --build-arg LDFLAGS="${LDFLAGS}" --build-arg GOARCH="${GOARCH}"
+	docker build . -t ${IMG} --build-arg FIPS_ENABLED="${FIPS_ENABLED}" --build-arg LDFLAGS="${LDFLAGS}" --build-arg GOARCH="${GOARCH}"
 
 # Push the docker image
 docker-push:
 	docker push ${IMG}
 
 docker-buildx-ci:
-	docker buildx build . --build-arg LDFLAGS="${LDFLAGS}" --platform=linux/arm64,linux/amd64 --label target=build --push --tag ${IMG} ${RELEASE_IMAGE_TAG}
+	docker buildx build . --build-arg FIPS_ENABLED="${FIPS_ENABLED}" --build-arg LDFLAGS="${LDFLAGS}" --platform=linux/arm64,linux/amd64 --label target=build --push --tag ${IMG} ${RELEASE_IMAGE_TAG}
 
 ##@ Tools
 CONTROLLER_GEN = bin/$(PLATFORM)/controller-gen

--- a/pkg/util/fipsonly.go
+++ b/pkg/util/fipsonly.go
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build fips
+
+package util
+
+import _ "crypto/tls/fipsonly"


### PR DESCRIPTION
### What does this PR do?

This change updates the dockerfile and build scripts to allow building a fips-compliant version of the WPA image

The bulk of the changes were copied over from [the similar change](https://github.com/DataDog/datadog-operator/pull/1731) made to the datadog-operator repo

### Motivation

What inspired you to submit this pull request?

### Additional Notes

More details on testing can be found in this [images PR](https://github.com/DataDog/images/pull/6944)

### Describe your test plan

Write there any instructions and details you may have to test your PR.
