### PR TITLE
Remove global gitlab cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,10 +9,6 @@ variables:
   DOCKER_REGISTRY_PWD_SSM_KEY: docker_hub_pwd
   DOCKER_REGISTRY_URL: docker.io
   FIPS_ENABLED: false
-cache: &global_cache
-  key: ${CI_COMMIT_REF_SLUG}
-  paths:
-    - /go/pkg/mod
 
 stages:
   - build


### PR DESCRIPTION
### What does this PR do?

Remove global gitlab cache

### Motivation

The build consistently fails on main since this was re-introduced [here](https://github.com/DataDog/watermarkpodautoscaler/pull/237)

More investigation needs to be done as to why, but in the interim the goal is to fix builds on main

[CI history over the last 6 months](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20%40ci.pipeline.name%3A%22DataDog%2Fwatermarkpodautoscaler%22%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&colorBy=meta%5B%27ci.stage.name%27%5D&colorByAttr=meta%5B%27ci.stage.name%27%5D&currentTab=trace&fromUser=true&graphType=span_list&index=cipipeline&spanViewType=metadata&start=1728583428248&end=1744135428248&paused=false), note that the only time main succeeded was during the small window where the cache was removed

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
