### PR TITLE
Fix the metric_name: label when using a recommender

### DIFF
--- a/controllers/datadoghq/replica_calculator.go
+++ b/controllers/datadoghq/replica_calculator.go
@@ -279,7 +279,7 @@ func (c *ReplicaCalculator) GetRecommenderReplicas(ctx context.Context, logger l
 	}
 
 	// This is because most of the code expects a metric name, so we assume that the recommender is the metric name.
-	var metricName = wpa.Spec.Recommender.URL
+	var metricName = metricNameForRecommender(&wpa.Spec)
 
 	minReplicas := int32(0)
 	if wpa.Spec.MinReplicas != nil {


### PR DESCRIPTION
This pull request modifies the logic for determining the metric name in the `ReplicaCalculator`, we don't want the URL as a tag here we want a recommender name we compute from the settings.