### PR TITLE
[SINT-3862] on-board to dd-octo-sts

### DIFF
--- a/.github/chainguard/self.pr-backport.create-pr.sts.yaml
+++ b/.github/chainguard/self.pr-backport.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/watermarkpodautoscaler:pull_request
+
+claim_pattern:
+  event_name: pull_request_target
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/watermarkpodautoscaler/\.github/workflows/pr-backport\.yaml@refs/heads/main
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -5,13 +5,12 @@ on:
       - closed
       - labeled
 
-permissions:
-  id-token: write # Needed to federate tokens for dd-octo-sts
-
 jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Needed to federate tokens for dd-octo-sts
     if: >
       github.event.pull_request.merged
       && (

--- a/.github/workflows/pr-backport.yaml
+++ b/.github/workflows/pr-backport.yaml
@@ -5,7 +5,8 @@ on:
       - closed
       - labeled
 
-permissions: {}
+permissions:
+  id-token: write # Needed to federate tokens for dd-octo-sts
 
 jobs:
   backport:
@@ -20,15 +21,17 @@ jobs:
           && contains(github.event.label.name, 'backport')
         )
       )
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+        id: octo-sts
+        with:
+          scope: DataDog/watermarkpodautoscaler
+          policy: self.pr-backport.create-pr
       - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           label_pattern: "^backport/(?<base>([^ ]+))$"
           labels_template: "<%= JSON.stringify([...labels, 'backport', 'bot']) %>"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.octo-sts.outputs.token }}
           body_template: |
             Backport <%- mergeCommitSha %> from #<%- number %>.
 


### PR DESCRIPTION
### What does this PR do?

This is part of an initiative lead by SDLC security to [harden Github security settings](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3913581900/GitHub+Workflow+Token+Permissions+GITHUB_TOKEN). To do so, we need to move away from GITHUB_TOKEN having the permission to approve and merge PRs, which is a behaviour we see in this repo.

Instead, [dd-octo-sts](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/4705912130/DD+Octo+STS) is an alternative to provide ephemeral scoped tokens delivering the same features with improved security.

This PR implements the migration to dd-octo-sts.
