### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,5 +6,5 @@
 *                   @DataDog/wpa-maintainers
 
 # Documentation
-README.md             @DataDog/documentation @DataDog/wpa-maintainers
-/docs/                @DataDog/documentation @DataDog/wpa-maintainers
+README.md             @DataDog/wpa-maintainers
+/docs/                @DataDog/wpa-maintainers


### PR DESCRIPTION
### What does this PR do?

Removes Docs as CODEOWNERS from the repo. As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
