### PR TITLE
enhancement: per-metric option for scaling delay behavior across multiple metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,10 @@ Or in the logs of the controller:
 {"level":"info","ts":1668481092517.446,"logger":"controllers.WatermarkPodAutoscaler","msg":"Will not scale: value has not been out of bounds for long enough","watermarkpodautoscaler":"datadog/example-watermarkpodautoscaler","wpa_name":"example-watermarkpodautoscaler","wpa_namespace":"datadog","time_left":3209}
 ```
 
-**Note:** If you are using multiple metrics with this feature, the above/below condition is considered using the `OR` of the metrics.
+**Note:** When multiple metrics are configured, the above/below condition defaults to the `OR` of the metrics. The behavior is configurable via `multiMetricsDelayMode`:
 
-For example, suppose you have a 60 second `upscaleDelay` with two metrics, M1 and M2. If M1 stays above its high watermark for 40 seconds `[t0; t40]`, and the M2 one goes above its high watermark for 30 seconds, overlapping with M1 during its last 10 seconds, `[t30; t60]`, this validates the `upscaleDelay` condition and allows for an upscaling event.
+- `aggregate` (default): the delay is satisfied as soon as **at least one** metric has been out of bounds for the configured duration, even if different metrics contribute to the window. For example, with a 60 second `upscaleDelay` and two metrics M1 and M2: if M1 stays above its high watermark for 40 seconds `[t0; t40]` and M2 goes above its high watermark for 30 seconds overlapping with M1 during its last 10 seconds `[t30; t60]`, this validates the `upscaleDelay` condition and allows for an upscaling event.
+- `per-metric`: the delay is satisfied only when **the same single metric** stays out of bounds continuously for the full configured duration. In the example above, neither M1 (40s) nor M2 (30s) was individually out of bounds for the full 60 seconds, so no scaling event would be allowed. With a single configured metric the behavior is identical to `aggregate`.
 
 * **Precedence**
 <a name="precedence"></a>

--- a/apis/datadoghq/v1alpha1/watermarkpodautoscaler_default.go
+++ b/apis/datadoghq/v1alpha1/watermarkpodautoscaler_default.go
@@ -51,6 +51,9 @@ func DefaultWatermarkPodAutoscaler(wpa *WatermarkPodAutoscaler) *WatermarkPodAut
 	if wpa.Spec.UpscaleForbiddenWindowSeconds == 0 {
 		defaultWPA.Spec.UpscaleForbiddenWindowSeconds = defaultUpscaleForbiddenWindowSeconds
 	}
+	if wpa.Spec.MultiMetricsDelayMode == "" {
+		defaultWPA.Spec.MultiMetricsDelayMode = MultiMetricsDelayModeAggregate
+	}
 	return defaultWPA
 }
 
@@ -80,6 +83,9 @@ func IsDefaultWatermarkPodAutoscaler(wpa *WatermarkPodAutoscaler) bool {
 	if wpa.Spec.UpscaleForbiddenWindowSeconds == 0 {
 		return false
 	}
+	if wpa.Spec.MultiMetricsDelayMode == "" {
+		return false
+	}
 	return true
 }
 
@@ -106,6 +112,11 @@ func CheckWPAValidity(wpa *WatermarkPodAutoscaler) error {
 	}
 	if wpa.Spec.Recommender != nil && wpa.Spec.Metrics != nil && len(wpa.Spec.Metrics) > 0 {
 		return fmt.Errorf("recommender and metrics can't be set at the same time, please choose one")
+	}
+	switch wpa.Spec.MultiMetricsDelayMode {
+	case "", MultiMetricsDelayModeAggregate, MultiMetricsDelayModePerMetric:
+	default:
+		return fmt.Errorf("invalid multiMetricsDelayMode %q, must be one of %q or %q", wpa.Spec.MultiMetricsDelayMode, MultiMetricsDelayModeAggregate, MultiMetricsDelayModePerMetric)
 	}
 	return checkWPAMetricsValidity(wpa)
 }

--- a/apis/datadoghq/v1alpha1/watermarkpodautoscaler_types.go
+++ b/apis/datadoghq/v1alpha1/watermarkpodautoscaler_types.go
@@ -62,6 +62,25 @@ var (
 	ConvergeDownwards ConvergeTowardsWatermarkType = "lowwatermark"
 )
 
+// MultiMetricsDelayMode controls how upscaleDelayAboveWatermarkSeconds and
+// downscaleDelayBelowWatermarkSeconds are evaluated when the spec contains
+// more than one metric.
+type MultiMetricsDelayMode string
+
+const (
+	// MultiMetricsDelayModeAggregate (default) maintains the historical behavior:
+	// the delay timer starts when at least one metric is out of bounds and
+	// resets only once every metric is back within its watermarks. This is the
+	// "OR" behavior — overlapping out-of-bounds windows from different metrics
+	// can satisfy the delay together.
+	MultiMetricsDelayModeAggregate MultiMetricsDelayMode = "aggregate"
+	// MultiMetricsDelayModePerMetric requires that the same single metric
+	// stays out of bounds continuously for the configured delay before
+	// allowing a scaling event. With a single metric the behavior is
+	// equivalent to aggregate.
+	MultiMetricsDelayModePerMetric MultiMetricsDelayMode = "per-metric"
+)
+
 // WatermarkPodAutoscalerSpec defines the desired state of WatermarkPodAutoscaler
 // +k8s:openapi-gen=true
 type WatermarkPodAutoscalerSpec struct {
@@ -87,6 +106,18 @@ type WatermarkPodAutoscalerSpec struct {
 
 	// +kubebuilder:validation:Minimum=0
 	DownscaleDelayBelowWatermarkSeconds int32 `json:"downscaleDelayBelowWatermarkSeconds,omitempty"`
+
+	// MultiMetricsDelayMode controls how upscaleDelayAboveWatermarkSeconds and
+	// downscaleDelayBelowWatermarkSeconds are evaluated when the spec contains
+	// more than one metric. With "aggregate" (default) the delay is satisfied
+	// as soon as at least one metric has been out of bounds for the configured
+	// duration, even if different metrics contribute to the window. With
+	// "per-metric" the delay is satisfied only when the same metric stays out
+	// of bounds for the full duration. Behavior is equivalent for a single
+	// metric.
+	// +optional
+	// +kubebuilder:validation:Enum=aggregate;per-metric
+	MultiMetricsDelayMode MultiMetricsDelayMode `json:"multiMetricsDelayMode,omitempty"`
 
 	// Number of replicas to scale by at a time. When set, replicas added or removed must be a multiple of this parameter.
 	// Allows for special scaling patterns, for instance when an application requires a certain number of pods in multiple

--- a/apis/datadoghq/v1alpha1/zz_generated.openapi.go
+++ b/apis/datadoghq/v1alpha1/zz_generated.openapi.go
@@ -399,6 +399,13 @@ func schema_watermarkpodautoscaler_apis_datadoghq_v1alpha1_WatermarkPodAutoscale
 							Format: "int32",
 						},
 					},
+					"multiMetricsDelayMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "MultiMetricsDelayMode controls how upscaleDelayAboveWatermarkSeconds and downscaleDelayBelowWatermarkSeconds are evaluated when the spec contains more than one metric. With \"aggregate\" (default) the delay is satisfied as soon as at least one metric has been out of bounds for the configured duration, even if different metrics contribute to the window. With \"per-metric\" the delay is satisfied only when the same metric stays out of bounds for the full duration. Behavior is equivalent for a single metric.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"replicaScalingAbsoluteModulo": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Number of replicas to scale by at a time. When set, replicas added or removed must be a multiple of this parameter. Allows for special scaling patterns, for instance when an application requires a certain number of pods in multiple",

--- a/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: watermarkpodautoscalers.datadoghq.com
 spec:
   group: datadoghq.com
@@ -282,6 +282,20 @@ spec:
                 format: int32
                 minimum: 1
                 type: integer
+              multiMetricsDelayMode:
+                description: |-
+                  MultiMetricsDelayMode controls how upscaleDelayAboveWatermarkSeconds and
+                  downscaleDelayBelowWatermarkSeconds are evaluated when the spec contains
+                  more than one metric. With "aggregate" (default) the delay is satisfied
+                  as soon as at least one metric has been out of bounds for the configured
+                  duration, even if different metrics contribute to the window. With
+                  "per-metric" the delay is satisfied only when the same metric stays out
+                  of bounds for the full duration. Behavior is equivalent for a single
+                  metric.
+                enum:
+                - aggregate
+                - per-metric
+                type: string
               readinessDelaySeconds:
                 format: int32
                 minimum: 1

--- a/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
+++ b/config/crd/bases/v1beta1/datadoghq.com_watermarkpodautoscalers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.3
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: watermarkpodautoscalers.datadoghq.com
 spec:
   group: datadoghq.com
@@ -275,6 +275,20 @@ spec:
                   format: int32
                   minimum: 1
                   type: integer
+                multiMetricsDelayMode:
+                  description: |-
+                    MultiMetricsDelayMode controls how upscaleDelayAboveWatermarkSeconds and
+                    downscaleDelayBelowWatermarkSeconds are evaluated when the spec contains
+                    more than one metric. With "aggregate" (default) the delay is satisfied
+                    as soon as at least one metric has been out of bounds for the configured
+                    duration, even if different metrics contribute to the window. With
+                    "per-metric" the delay is satisfied only when the same metric stays out
+                    of bounds for the full duration. Behavior is equivalent for a single
+                    metric.
+                  enum:
+                    - aggregate
+                    - per-metric
+                  type: string
                 readinessDelaySeconds:
                   format: int32
                   minimum: 1

--- a/controllers/datadoghq/watermarkpodautoscaler_controller.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller.go
@@ -679,8 +679,8 @@ func perMetricBelowLowType(key string) autoscalingv2.HorizontalPodAutoscalerCond
 // on the WPA status without affecting LastConditionType / LastConditionState
 // or the prom condition gauge — those remain owned by the aggregate
 // conditions for backwards compatibility.
-func setPerMetricCondition(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, conditionType autoscalingv2.HorizontalPodAutoscalerConditionType, status corev1.ConditionStatus, reason, format string, args ...interface{}) {
-	wpa.Status.Conditions = setConditionInList(wpa.Status.Conditions, conditionType, status, reason, format, args...)
+func setPerMetricCondition(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, conditionType autoscalingv2.HorizontalPodAutoscalerConditionType, status corev1.ConditionStatus, reason, message string, args ...interface{}) {
+	wpa.Status.Conditions = setConditionInList(wpa.Status.Conditions, conditionType, status, reason, message, args...)
 }
 
 // updatePerMetricConditions records the current above/below state of a single

--- a/controllers/datadoghq/watermarkpodautoscaler_controller.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller.go
@@ -589,21 +589,27 @@ func shouldScale(logger logr.Logger, wpa *datadoghqv1alpha1.WatermarkPodAutoscal
 
 	logger.Info("Cooldown status", "backoffUp", backoffUp, "backoffDown", backoffDown, "desiredReplicas", desiredReplicas, "currentReplicas", currentReplicas)
 
-	hasBeenAbove, err := getCondition(&wpa.Status, datadoghqv1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark)
-	if err != nil {
-		logger.V(2).Info("Could not retrieve condition about the time above Watermark, blocking potential scaling event", "error", err)
-		hasBeenAbove.Status = corev1.ConditionFalse
-	}
 	if desiredReplicas > currentReplicas {
+		if usePerMetricDelay(wpa) {
+			return canScaleAfterDelayPerMetric(logger, backoffUp, wpa, perMetricAboveHighType, wpa.Spec.UpscaleDelayAboveWatermarkSeconds, isStable)
+		}
+		hasBeenAbove, err := getCondition(&wpa.Status, datadoghqv1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark)
+		if err != nil {
+			logger.V(2).Info("Could not retrieve condition about the time above Watermark, blocking potential scaling event", "error", err)
+			hasBeenAbove.Status = corev1.ConditionFalse
+		}
 		return canScaleAfterDelay(logger, backoffUp, hasBeenAbove, wpa.Spec.UpscaleDelayAboveWatermarkSeconds, isStable)
 	}
 
-	hasBeenBelow, err := getCondition(&wpa.Status, datadoghqv1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark)
-	if err != nil {
-		logger.V(2).Info("Could not retrieve condition about the time above Watermark, blocking potential scaling event", "error", err)
-		hasBeenBelow.Status = corev1.ConditionFalse
-	}
 	if desiredReplicas < currentReplicas {
+		if usePerMetricDelay(wpa) {
+			return canScaleAfterDelayPerMetric(logger, backoffDown, wpa, perMetricBelowLowType, wpa.Spec.DownscaleDelayBelowWatermarkSeconds, isStable)
+		}
+		hasBeenBelow, err := getCondition(&wpa.Status, datadoghqv1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark)
+		if err != nil {
+			logger.V(2).Info("Could not retrieve condition about the time below Watermark, blocking potential scaling event", "error", err)
+			hasBeenBelow.Status = corev1.ConditionFalse
+		}
 		return canScaleAfterDelay(logger, backoffDown, hasBeenBelow, wpa.Spec.DownscaleDelayBelowWatermarkSeconds, isStable)
 	}
 	logger.Info("Will not scale: number of replicas has not changed")
@@ -625,6 +631,120 @@ func canScaleAfterDelay(logger logr.Logger, isBackoff bool, wasOutOfBounds autos
 		return false
 	}
 	return !isBackoff
+}
+
+// usePerMetricDelay returns true when the spec asks for per-metric delay
+// evaluation and there is more than one metric to compare. With a single
+// metric the per-metric and aggregate behaviors are equivalent, so we keep
+// the aggregate path to avoid any behavioral change for that case.
+func usePerMetricDelay(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler) bool {
+	return wpa.Spec.MultiMetricsDelayMode == datadoghqv1alpha1.MultiMetricsDelayModePerMetric && len(wpa.Spec.Metrics) > 1
+}
+
+// metricConditionKey returns a stable identifier for a metric used to suffix
+// the per-metric AboveHighWatermark / BelowLowWatermark condition types.
+func metricConditionKey(metricSpec datadoghqv1alpha1.MetricSpec) string {
+	switch metricSpec.Type {
+	case datadoghqv1alpha1.ExternalMetricSourceType:
+		if metricSpec.External == nil {
+			return ""
+		}
+		var labels map[string]string
+		if metricSpec.External.MetricSelector != nil {
+			labels = metricSpec.External.MetricSelector.MatchLabels
+		}
+		return fmt.Sprintf("%s{%v}", metricSpec.External.MetricName, labels)
+	case datadoghqv1alpha1.ResourceMetricSourceType:
+		if metricSpec.Resource == nil {
+			return ""
+		}
+		var labels map[string]string
+		if metricSpec.Resource.MetricSelector != nil {
+			labels = metricSpec.Resource.MetricSelector.MatchLabels
+		}
+		return fmt.Sprintf("%s{%v}", metricSpec.Resource.Name, labels)
+	}
+	return ""
+}
+
+func perMetricAboveHighType(key string) autoscalingv2.HorizontalPodAutoscalerConditionType {
+	return autoscalingv2.HorizontalPodAutoscalerConditionType(string(datadoghqv1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark) + "/" + key)
+}
+
+func perMetricBelowLowType(key string) autoscalingv2.HorizontalPodAutoscalerConditionType {
+	return autoscalingv2.HorizontalPodAutoscalerConditionType(string(datadoghqv1alpha1.WatermarkPodAutoscalerStatusBelowLowWatermark) + "/" + key)
+}
+
+// setPerMetricCondition adds or updates a per-metric out-of-bounds condition
+// on the WPA status without affecting LastConditionType / LastConditionState
+// or the prom condition gauge — those remain owned by the aggregate
+// conditions for backwards compatibility.
+func setPerMetricCondition(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, conditionType autoscalingv2.HorizontalPodAutoscalerConditionType, status corev1.ConditionStatus, reason, format string, args ...interface{}) {
+	wpa.Status.Conditions = setConditionInList(wpa.Status.Conditions, conditionType, status, reason, format, args...)
+}
+
+// updatePerMetricConditions records the current above/below state of a single
+// metric on the WPA status. Only invoked when per-metric delay mode is
+// enabled — otherwise we avoid adding extra conditions to the status.
+func updatePerMetricConditions(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, metricSpec datadoghqv1alpha1.MetricSpec, metricName string, pos metricPosition) {
+	if wpa.Spec.MultiMetricsDelayMode != datadoghqv1alpha1.MultiMetricsDelayModePerMetric {
+		return
+	}
+	key := metricConditionKey(metricSpec)
+	if key == "" {
+		return
+	}
+	aboveStatus := corev1.ConditionFalse
+	if pos.isAbove {
+		aboveStatus = corev1.ConditionTrue
+	}
+	belowStatus := corev1.ConditionFalse
+	if pos.isBelow {
+		belowStatus = corev1.ConditionTrue
+	}
+	setPerMetricCondition(wpa, perMetricAboveHighType(key), aboveStatus, aboveHighWatermarkReason, "%s for metric %s", aboveHighWatermarkAllowedMessage, metricName)
+	setPerMetricCondition(wpa, perMetricBelowLowType(key), belowStatus, belowLowWatermarkReason, "%s for metric %s", belowLowWatermarkAllowedMessage, metricName)
+}
+
+// canScaleAfterDelayPerMetric is the per-metric variant of canScaleAfterDelay.
+// It allows scaling iff at least one of the configured metrics has had its
+// per-metric out-of-bounds condition continuously True for at least
+// decisionDelay seconds. The same metric must satisfy the full window;
+// overlapping windows from different metrics do not combine.
+func canScaleAfterDelayPerMetric(logger logr.Logger, isBackoff bool, wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, perMetricType func(string) autoscalingv2.HorizontalPodAutoscalerConditionType, decisionDelay int32, isStable bool) bool {
+	if decisionDelay == 0 || isStable {
+		return !isBackoff
+	}
+
+	now := metav1.Now()
+	bestRemaining := decisionDelay
+	closestKey := ""
+	hasOOBMetric := false
+	for _, metricSpec := range wpa.Spec.Metrics {
+		key := metricConditionKey(metricSpec)
+		if key == "" {
+			continue
+		}
+		cond, err := getCondition(&wpa.Status, perMetricType(key))
+		if err != nil || cond.Status != corev1.ConditionTrue {
+			continue
+		}
+		hasOOBMetric = true
+		remaining := decisionDelay - int32(now.Sub(cond.LastTransitionTime.Time).Seconds())
+		if remaining <= 0 {
+			return !isBackoff
+		}
+		if closestKey == "" || remaining < bestRemaining {
+			bestRemaining = remaining
+			closestKey = key
+		}
+	}
+	if !hasOOBMetric {
+		logger.Info("Will not scale: no metric is currently out of bounds")
+		return false
+	}
+	logger.Info("Will not scale: no single metric has been out of bounds for long enough", "time_left", bestRemaining, "closest_metric", closestKey)
+	return false
 }
 
 // setCurrentReplicasInStatus sets the current replica count in the status of the HPA.
@@ -735,10 +855,14 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasForMetrics(ctx context
 				utilizationProposal = replicaCalculation.utilization
 				timestampProposal = replicaCalculation.timestamp
 				readyReplicasProposal = replicaCalculation.readyReplicas
-				// If multiple metrics are used, we keep track of whether at least one of them is outside of the bounds.
-				// This is later used for the delayScaling feature, which only supports `OR` for now.
+				// Aggregate ("OR") tracking — used by the default
+				// MultiMetricsDelayMode=aggregate path.
 				isAbove = isAbove || replicaCalculation.pos.isAbove
 				isBelow = isBelow || replicaCalculation.pos.isBelow
+				// Per-metric tracking — when MultiMetricsDelayMode=per-metric,
+				// each metric's out-of-bounds duration is tracked
+				// independently via its own condition.
+				updatePerMetricConditions(wpa, metricSpec, metricNameProposal, replicaCalculation.pos)
 
 				lowwm.With(wpaLabels).Set(float64(metricSpec.External.LowWatermark.MilliValue()))
 				lowwmV2.With(wpaLabels).Set(float64(metricSpec.External.LowWatermark.MilliValue()))
@@ -776,10 +900,13 @@ func (r *WatermarkPodAutoscalerReconciler) computeReplicasForMetrics(ctx context
 				utilizationProposal = replicaCalculation.utilization
 				timestampProposal = replicaCalculation.timestamp
 				readyReplicasProposal = replicaCalculation.readyReplicas
-				// If multiple metrics are used, we keep track of whether at least one of them is outside of the bounds.
-				// This is later used for the delayScaling feature, which only supports `OR` for now.
+				// Aggregate ("OR") tracking — used by the default
+				// MultiMetricsDelayMode=aggregate path.
 				isAbove = isAbove || replicaCalculation.pos.isAbove
 				isBelow = isBelow || replicaCalculation.pos.isBelow
+				// Per-metric tracking — see equivalent block in the External
+				// branch above.
+				updatePerMetricConditions(wpa, metricSpec, metricNameProposal, replicaCalculation.pos)
 
 				lowwm.With(wpaLabels).Set(float64(metricSpec.Resource.LowWatermark.MilliValue()))
 				lowwmV2.With(wpaLabels).Set(float64(metricSpec.Resource.LowWatermark.MilliValue()))

--- a/controllers/datadoghq/watermarkpodautoscaler_controller_test.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller_test.go
@@ -2192,6 +2192,80 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 			},
 			shoudScale: false,
 		},
+		{
+			// per-metric mode: M1 below low for 40s and M2 below low for 30s with no
+			// overlap window long enough on either single metric. With aggregate
+			// (default) mode this would scale; with per-metric it must not.
+			name: "per-metric: overlapping per-metric windows do not satisfy delay (downscale)",
+			args: args{
+				currentReplicas: 8,
+				desiredReplicas: 6,
+				timestamp:       time.Unix(1232599, 0),
+				wpa: makePerMetricDelayWPA(t, perMetricDelayWPAOpts{
+					mode: v1alpha1.MultiMetricsDelayModePerMetric,
+					downscaleDelay: 60,
+					m1Below: 40 * time.Second,
+					m2Below: 30 * time.Second,
+				}),
+			},
+			shoudScale: false,
+		},
+		{
+			// per-metric mode: M1 has been below low for 90s (≥ 60s delay) on its own.
+			// Even though M2 has only been below for 30s, M1 alone satisfies the delay.
+			name: "per-metric: a single metric out of bounds for full delay allows scaling (downscale)",
+			args: args{
+				currentReplicas: 8,
+				desiredReplicas: 6,
+				timestamp:       time.Unix(1232599, 0),
+				wpa: makePerMetricDelayWPA(t, perMetricDelayWPAOpts{
+					mode: v1alpha1.MultiMetricsDelayModePerMetric,
+					downscaleDelay: 60,
+					m1Below: 90 * time.Second,
+					m2Below: 30 * time.Second,
+				}),
+			},
+			shoudScale: true,
+		},
+		{
+			// per-metric mode with a single configured metric must behave exactly
+			// like the aggregate path: the aggregate AboveHighWatermark condition
+			// satisfied for ≥ delay seconds is enough to scale.
+			name: "per-metric: single metric falls back to aggregate behavior (upscale)",
+			args: args{
+				currentReplicas: 6,
+				desiredReplicas: 8,
+				timestamp:       time.Unix(1232599, 0),
+				wpa: test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
+					Spec: &v1alpha1.WatermarkPodAutoscalerSpec{
+						UpscaleForbiddenWindowSeconds:     60,
+						DownscaleForbiddenWindowSeconds:   60,
+						UpscaleDelayAboveWatermarkSeconds: 60,
+						MultiMetricsDelayMode:             v1alpha1.MultiMetricsDelayModePerMetric,
+						Metrics: []v1alpha1.MetricSpec{
+							{
+								Type: v1alpha1.ExternalMetricSourceType,
+								External: &v1alpha1.ExternalMetricSource{
+									MetricName:     "m1",
+									MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"k": "v"}},
+								},
+							},
+						},
+					},
+					Status: &v1alpha1.WatermarkPodAutoscalerStatus{
+						LastScaleTime: &metav1.Time{Time: time.Unix(1232000, 0)},
+						Conditions: []v2beta1.HorizontalPodAutoscalerCondition{
+							{
+								Type:               v1alpha1.WatermarkPodAutoscalerStatusAboveHighWatermark,
+								Status:             corev1.ConditionTrue,
+								LastTransitionTime: metav1.Time{Time: time.Now().Add(-90 * time.Second)},
+							},
+						},
+					},
+				}),
+			},
+			shoudScale: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2201,6 +2275,72 @@ func TestReconcileWatermarkPodAutoscaler_shouldScale(t *testing.T) {
 			}
 		})
 	}
+}
+
+type perMetricDelayWPAOpts struct {
+	mode           v1alpha1.MultiMetricsDelayMode
+	upscaleDelay   int32
+	downscaleDelay int32
+	// Below low watermark durations for the two test metrics. Zero means the
+	// metric is not currently below the low watermark.
+	m1Below time.Duration
+	m2Below time.Duration
+	// Above high watermark durations.
+	m1Above time.Duration
+	m2Above time.Duration
+}
+
+// makePerMetricDelayWPA builds a WPA with two external metrics configured for
+// the per-metric delay tests. Per-metric conditions are pre-populated on the
+// status so the test can simulate "this metric has been out of bounds for X
+// seconds" without needing to drive the reconcile loop.
+func makePerMetricDelayWPA(t *testing.T, opts perMetricDelayWPAOpts) *v1alpha1.WatermarkPodAutoscaler {
+	t.Helper()
+	m1 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ExternalMetricSourceType,
+		External: &v1alpha1.ExternalMetricSource{
+			MetricName:     "m1",
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"k": "v1"}},
+		},
+	}
+	m2 := v1alpha1.MetricSpec{
+		Type: v1alpha1.ExternalMetricSourceType,
+		External: &v1alpha1.ExternalMetricSource{
+			MetricName:     "m2",
+			MetricSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"k": "v2"}},
+		},
+	}
+	now := time.Now()
+	var conds []v2beta1.HorizontalPodAutoscalerCondition
+	addCond := func(metric v1alpha1.MetricSpec, builder func(string) v2beta1.HorizontalPodAutoscalerConditionType, dur time.Duration) {
+		if dur <= 0 {
+			return
+		}
+		conds = append(conds, v2beta1.HorizontalPodAutoscalerCondition{
+			Type:               builder(metricConditionKey(metric)),
+			Status:             corev1.ConditionTrue,
+			LastTransitionTime: metav1.Time{Time: now.Add(-dur)},
+		})
+	}
+	addCond(m1, perMetricBelowLowType, opts.m1Below)
+	addCond(m2, perMetricBelowLowType, opts.m2Below)
+	addCond(m1, perMetricAboveHighType, opts.m1Above)
+	addCond(m2, perMetricAboveHighType, opts.m2Above)
+
+	return test.NewWatermarkPodAutoscaler(testingNamespace, testingWPAName, &test.NewWatermarkPodAutoscalerOptions{
+		Spec: &v1alpha1.WatermarkPodAutoscalerSpec{
+			UpscaleForbiddenWindowSeconds:       60,
+			DownscaleForbiddenWindowSeconds:     60,
+			UpscaleDelayAboveWatermarkSeconds:   opts.upscaleDelay,
+			DownscaleDelayBelowWatermarkSeconds: opts.downscaleDelay,
+			MultiMetricsDelayMode:               opts.mode,
+			Metrics:                             []v1alpha1.MetricSpec{m1, m2},
+		},
+		Status: &v1alpha1.WatermarkPodAutoscalerStatus{
+			LastScaleTime: &metav1.Time{Time: time.Unix(1232000, 0)},
+			Conditions:    conds,
+		},
+	})
 }
 
 func TestCalculateScaleUpLimit(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Adds a new spec field, `MultiMetricsDelayMode`, that controls how upscaleDelayAboveWatermarkSeconds and downscaleDelayBelowWatermarkSeconds are evaluated across multiple metrics. The default "aggregate" mode preserves the existing OR behavior where overlapping out-of-bounds windows from different metrics combine to satisfy the delay. The new "per-metric" mode requires the same single metric to stay out of bounds continuously for the full duration before allowing a scaling event. Single-metric specs are unaffected.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details you may have to test your PR.
