### PR TITLE
Revert "Add dry_run label to all WPA Prometheus metrics"

### DIFF
--- a/controllers/datadoghq/metrics.go
+++ b/controllers/datadoghq/metrics.go
@@ -7,7 +7,6 @@ package datadoghq
 
 import (
 	"os"
-	"strconv"
 	"strings"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta1"
@@ -35,7 +34,6 @@ const (
 	lifecycleStatus            = "lifecycle_status"
 	monitorName                = "monitor_name"
 	monitorNamespace           = "monitor_namespace"
-	dryRunPromLabel            = "dry_run"
 	clientPromLabel            = "client"
 	methodPromLabel            = "method"
 	codePromLabel              = "code"
@@ -64,7 +62,6 @@ var defaultPromLabels = []string{
 	resourceKindPromLabel,
 	targetNamePromLabel,
 	namespacePromLabel,
-	dryRunPromLabel,
 }
 
 // Labels to add to an info metric and join on (with wpaNamePromLabel) in the Datadog prometheus check
@@ -131,7 +128,6 @@ var (
 			lifecycleStatus,
 			monitorName,
 			monitorNamespace,
-			dryRunPromLabel,
 		},
 	)
 	lowwm = prometheus.NewGaugeVec(
@@ -212,7 +208,7 @@ var (
 			Name:      "labels_info",
 			Help:      "Info metric for additional labels to associate to metrics as tags",
 		},
-		append(extraPromLabels, wpaNamePromLabel, wpaNamespacePromLabel, resourceNamespacePromLabel, namespacePromLabel, dryRunPromLabel),
+		append(extraPromLabels, wpaNamePromLabel, wpaNamespacePromLabel, resourceNamespacePromLabel, namespacePromLabel),
 	)
 	requestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -295,7 +291,12 @@ func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onl
 		transitionCountdown.Delete(promLabelsForWpa)
 		delete(promLabelsForWpa, transitionPromLabel)
 
-		labelsInfo.DeletePartialMatch(prometheus.Labels{wpaNamePromLabel: wpa.Name, wpaNamespacePromLabel: wpa.Namespace, resourceNamespacePromLabel: wpa.Namespace})
+		promLabelsInfo := prometheus.Labels{wpaNamePromLabel: wpa.Name, wpaNamespacePromLabel: wpa.Namespace, resourceNamespacePromLabel: wpa.Namespace}
+		for _, eLabel := range extraPromLabels {
+			eLabelValue := wpa.Labels[eLabel]
+			promLabelsInfo[eLabel] = eLabelValue
+		}
+		labelsInfo.Delete(promLabelsInfo)
 		dryRun.Delete(promLabelsForWpa)
 
 		scalingActive.Delete(promLabelsForWpa)
@@ -328,7 +329,6 @@ func cleanupAssociatedMetrics(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, onl
 		lifecycleStatus:       lifecycleControlBlockedStatus,
 		monitorName:           wpa.Name,
 		monitorNamespace:      wpa.Namespace,
-		dryRunPromLabel:       strconv.FormatBool(wpa.Spec.DryRun),
 	})
 }
 
@@ -352,6 +352,5 @@ func getPrometheusLabels(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler) promethe
 		resourceKindPromLabel:      wpa.Spec.ScaleTargetRef.Kind,
 		targetNamePromLabel:        wpa.Spec.ScaleTargetRef.Name,
 		namespacePromLabel:         wpa.Namespace,
-		dryRunPromLabel:            strconv.FormatBool(wpa.Spec.DryRun),
 	}
 }

--- a/controllers/datadoghq/replica_calculator.go
+++ b/controllers/datadoghq/replica_calculator.go
@@ -141,7 +141,7 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(ctx context.Context, logge
 		restrictedScaling.Delete(labelsWithReason)
 		labelsWithReason[reasonPromLabel] = withinBoundsPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
-		value.DeletePartialMatch(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: metricName})
+		value.Delete(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: metricName})
 		return EmptyReplicaCalculation(), fmt.Errorf("unable to get external metric %s/%s/%+v: %s", wpa.Namespace, metricName, selector, err) //nolint:errorlint
 	}
 	logger.V(2).Info("Metrics from the External Metrics Provider", "metrics", metrics)
@@ -188,7 +188,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(ctx context.Context, logger logr
 		restrictedScaling.Delete(labelsWithReason)
 		labelsWithReason[reasonPromLabel] = withinBoundsPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
-		value.DeletePartialMatch(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: string(resourceName)})
+		value.Delete(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: string(resourceName)})
 		return EmptyReplicaCalculation(), fmt.Errorf("unable to get resource metric %s/%s/%+v: %s", wpa.Namespace, resourceName, selector, err) //nolint:errorlint
 	}
 	logger.Info("Metrics from the Resource Client", "metrics", metrics)
@@ -295,7 +295,7 @@ func (c *ReplicaCalculator) GetRecommenderReplicas(ctx context.Context, logger l
 		restrictedScaling.Delete(labelsWithReason)
 		labelsWithReason[reasonPromLabel] = withinBoundsPromLabelVal
 		restrictedScaling.Delete(labelsWithReason)
-		value.DeletePartialMatch(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: metricName})
+		value.Delete(prometheus.Labels{wpaNamePromLabel: wpa.Name, metricNamePromLabel: metricName})
 		return EmptyReplicaCalculation(), fmt.Errorf("unable to get external recommendation %+v: %s", metricName, err) //nolint:errorlint
 	}
 	logger.V(2).Info("Replica recommendation from the external replicas recommender", "replicas", reco.Replicas, "timestamp", reco.Timestamp, "details", reco.Details, "replicasLowerBound", reco.ReplicasLowerBound, "replicasUpperBound", reco.ReplicasUpperBound)

--- a/controllers/datadoghq/watermarkpodautoscaler_controller.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller.go
@@ -235,7 +235,6 @@ func (r *WatermarkPodAutoscalerReconciler) Reconcile(ctx context.Context, reques
 			monitorName:           instance.Name,
 			monitorNamespace:      instance.Namespace,
 			lifecycleStatus:       lifecycleControlBlockedStatus,
-			dryRunPromLabel:       strconv.FormatBool(instance.Spec.DryRun),
 		}
 		dmon := types.NamespacedName{
 			Name:      instance.Name,
@@ -371,7 +370,7 @@ func (r *WatermarkPodAutoscalerReconciler) reconcileWPA(ctx context.Context, log
 	span.SetTag("current_replicas", currentReplicas)
 
 	// add additional labels to info metric
-	promLabels := prometheus.Labels{wpaNamePromLabel: wpa.Name, wpaNamespacePromLabel: wpa.Namespace, resourceNamespacePromLabel: wpa.Namespace, namespacePromLabel: wpa.Namespace, dryRunPromLabel: strconv.FormatBool(wpa.Spec.DryRun)}
+	promLabels := prometheus.Labels{wpaNamePromLabel: wpa.Name, wpaNamespacePromLabel: wpa.Namespace, resourceNamespacePromLabel: wpa.Namespace, namespacePromLabel: wpa.Namespace}
 	for _, eLabel := range extraPromLabels {
 		eLabelValue := wpa.Labels[eLabel]
 		promLabels[eLabel] = eLabelValue

--- a/controllers/datadoghq/watermarkpodautoscaler_controller_test.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -2723,7 +2722,6 @@ func getPromBaseLabels(wpa *v1alpha1.WatermarkPodAutoscaler) prometheus.Labels {
 		resourceKindPromLabel:      wpa.Spec.ScaleTargetRef.Kind,
 		targetNamePromLabel:        wpa.Spec.ScaleTargetRef.Name,
 		namespacePromLabel:         wpa.Namespace,
-		dryRunPromLabel:            strconv.FormatBool(wpa.Spec.DryRun),
 	}
 }
 


### PR DESCRIPTION
Reverts DataDog/watermarkpodautoscaler#321

See https://app.datadoghq.com/incidents/54443