### PR TITLE
Onboard off public-images GitLab job-token trigger

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,7 @@ build_image_fips:
 
 .docker_publish_job_definition:
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  tags: ["arch:amd64"]
   before_script: []
   variables:
     IMG_SIGNING: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,7 +79,7 @@ build_image_fips:
 
 .docker_publish_job_definition:
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
-  tags: ["arch:amd64"]
+  tags: ["arch:arm64"]
   before_script: []
   variables:
     IMG_SIGNING: "false"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,8 +79,10 @@ build_image_fips:
 
 .docker_publish_job_definition:
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  before_script: []
   variables:
     IMG_SIGNING: "false"
+    IMG_REGISTRIES: "public"
     PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"
   script:
     - |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,7 +78,7 @@ build_image_fips:
     FIPS_ENABLED: "true"
 
 .docker_publish_job_definition:
-  image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.3
   tags: ["arch:arm64"]
   before_script: []
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,16 +77,32 @@ build_image_fips:
     RELEASE_IMAGE: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG-fips
     FIPS_ENABLED: "true"
 
+.docker_publish_job_definition:
+  image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.0
+  variables:
+    IMG_SIGNING: "false"
+    PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"
+  script:
+    - |
+      set -euo pipefail
+      dd-pkg version
+      args=(publish-image --timeout "${PUBLIC_IMAGES_PUBLISH_TIMEOUT}" --poll-interval 30 --signing="${IMG_SIGNING}")
+      if [[ -n "${IMG_REGISTRIES:-}" ]]; then args+=(--registries "${IMG_REGISTRIES}"); fi
+      if [[ -n "${IMG_SOURCES:-}" ]]; then args+=(--sources "${IMG_SOURCES}"); fi
+      if [[ -n "${IMG_DESTINATIONS:-}" ]]; then args+=(--destinations "${IMG_DESTINATIONS}"); fi
+      if [[ -n "${IMG_DESTINATIONS_REGEX:-}" ]]; then args+=(--regex-expression "${IMG_DESTINATIONS_REGEX}"); fi
+      if [[ -n "${IMG_DESTINATIONS_REGEX_REPL:-}" ]]; then args+=(--regex-replacement "${IMG_DESTINATIONS_REGEX_REPL}"); fi
+      if [[ -n "${IMG_TAG_REFERENCE:-}" ]]; then args+=(--tag-reference "${IMG_TAG_REFERENCE}"); fi
+      if [[ -n "${IMG_NEW_TAGS:-}" ]]; then args+=(--new-tags "${IMG_NEW_TAGS}"); fi
+      dd-pkg "${args[@]}"
+
 publish_public_main:
   stage: release
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
       when: on_success
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
     IMG_DESTINATIONS: $PROJECTNAME:main
@@ -98,10 +114,7 @@ publish_public_tag:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG
     IMG_DESTINATIONS: $PROJECTNAME:$CI_COMMIT_TAG
@@ -113,10 +126,7 @@ publish_public_latest:
     - if: $CI_COMMIT_TAG
       when: manual
     - when: never
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  extends: .docker_publish_job_definition
   variables:
     IMG_SOURCES: $BUILD_DOCKER_REGISTRY/$PROJECTNAME:$CI_COMMIT_TAG
     IMG_DESTINATIONS: $PROJECTNAME:latest


### PR DESCRIPTION
Replaces the legacy `trigger: project: DataDog/public-images` job with a direct `dd-pkg publish-image` call against artifact-gateway.

## Why

The GitLab job-token bridge cannot tell **who** triggered a publish — any project holding a token could publish anything. Calling artifact-gateway instead adds:

- **Authentication** — the caller's identity is verified.
- **Authorization** — a policy states which Directory Service group may release each image tier (dev vs prod).
- An audit trail of every publication.

**Authorization is in audit-only mode for now** — nothing is blocked, publications are only recorded. So this is safe to merge, and the rollout stays reversible behind a feature flag.

Publish cadence, tags and destinations are unchanged; this is an onboarding change only.

- Jira: [BARX-1952](https://datadoghq.atlassian.net/browse/BARX-1952)
- How-to: [Publish public images with dd-pkg](https://datadoghq.atlassian.net/wiki/x/ooQkngE)

[BARX-1952]: https://datadoghq.atlassian.net/browse/BARX-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ