### PR TITLE
[CASCL-1709] Fix stuck WPA restricted_scaling capping metric

### DIFF
--- a/controllers/datadoghq/metrics.go
+++ b/controllers/datadoghq/metrics.go
@@ -354,3 +354,12 @@ func getPrometheusLabels(wpa *datadoghqv1alpha1.WatermarkPodAutoscaler) promethe
 		namespacePromLabel:         wpa.Namespace,
 	}
 }
+
+// boolToFloat64 converts a boolean to the 1/0 float64 representation used by
+// Prometheus gauges.
+func boolToFloat64(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/controllers/datadoghq/watermarkpodautoscaler_controller.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller.go
@@ -949,26 +949,19 @@ func normalizeDesiredReplicas(logger logr.Logger, wpa *datadoghqv1alpha1.Waterma
 func convertDesiredReplicasWithRules(logger logr.Logger, wpa *datadoghqv1alpha1.WatermarkPodAutoscaler, currentReplicas, desiredReplicas, wpaMinReplicas, wpaMaxReplicas int32, readyReplicas int32) (int32, string, string) {
 	var minimumAllowedReplicas int32
 	var maximumAllowedReplicas int32
+	var normalizedReplicas int32
 	var possibleLimitingCondition string
 	var possibleLimitingReason string
 
 	// Track the capping decisions so that both the downscale_capping and
-	// upscale_capping restricted_scaling gauges are refreshed on every return
-	// path. Previously these gauges were only updated on the specific branch
-	// that computed them, so a gauge set to 1 during one reconcile could stay
-	// "stuck" at 1 on subsequent reconciles that no longer capped in that
-	// direction (see CASCL-1709).
+	// upscale_capping restricted_scaling gauges are refreshed on every
+	// reconcile. Previously these gauges were only updated on the specific
+	// branch that computed them, so a gauge set to 1 during one reconcile could
+	// stay "stuck" at 1 on subsequent reconciles that no longer capped in that
+	// direction (see CASCL-1709). The function funnels every path through a
+	// single exit so both gauges are always refreshed before returning.
 	downscaleCapping := false
 	upscaleCapping := false
-	defer func() {
-		downscaleLabels := getPrometheusLabels(wpa)
-		downscaleLabels[reasonPromLabel] = downscaleCappingPromLabelVal
-		restrictedScaling.With(downscaleLabels).Set(boolToFloat64(downscaleCapping))
-
-		upscaleLabels := getPrometheusLabels(wpa)
-		upscaleLabels[reasonPromLabel] = upscaleCappingPromLabelVal
-		restrictedScaling.With(upscaleLabels).Set(boolToFloat64(upscaleCapping))
-	}()
 
 	scaleDownLimit := calculateScaleDownLimit(wpa, currentReplicas)
 
@@ -993,33 +986,44 @@ func convertDesiredReplicasWithRules(logger logr.Logger, wpa *datadoghqv1alpha1.
 	}
 
 	if desiredReplicas < minimumAllowedReplicas {
-		return minimumAllowedReplicas, possibleLimitingCondition, possibleLimitingReason
-	}
-
-	scaleUpLimit := calculateScaleUpLimit(wpa, currentReplicas)
-
-	if desiredReplicas > scaleUpLimit {
-		maximumAllowedReplicas = int32(math.Min(float64(scaleUpLimit), float64(wpaMaxReplicas)))
-		upscaleCapping = true
-		logger.Info("Upscaling rate higher than limit set by 'ScaleUpLimitFactor', capping the maximum upscale to 'maximumAllowedReplicas'", "scaleUpLimitFactor", fmt.Sprintf("%.1f", float64(wpa.Spec.ScaleUpLimitFactor.MilliValue()/1000)), "wpaMaxReplicas", wpaMaxReplicas, "maximumAllowedReplicas", maximumAllowedReplicas)
-		possibleLimitingCondition = "ScaleUpLimit"
-		possibleLimitingReason = "the desired replica count is increasing faster than the maximum scale rate"
+		normalizedReplicas = minimumAllowedReplicas
 	} else {
-		maximumAllowedReplicas = wpaMaxReplicas
-		possibleLimitingCondition = "TooManyReplicas"
-		possibleLimitingReason = "the desired replica count is above the maximum replica count"
+		scaleUpLimit := calculateScaleUpLimit(wpa, currentReplicas)
+
+		if desiredReplicas > scaleUpLimit {
+			maximumAllowedReplicas = int32(math.Min(float64(scaleUpLimit), float64(wpaMaxReplicas)))
+			upscaleCapping = true
+			logger.Info("Upscaling rate higher than limit set by 'ScaleUpLimitFactor', capping the maximum upscale to 'maximumAllowedReplicas'", "scaleUpLimitFactor", fmt.Sprintf("%.1f", float64(wpa.Spec.ScaleUpLimitFactor.MilliValue()/1000)), "wpaMaxReplicas", wpaMaxReplicas, "maximumAllowedReplicas", maximumAllowedReplicas)
+			possibleLimitingCondition = "ScaleUpLimit"
+			possibleLimitingReason = "the desired replica count is increasing faster than the maximum scale rate"
+		} else {
+			maximumAllowedReplicas = wpaMaxReplicas
+			possibleLimitingCondition = "TooManyReplicas"
+			possibleLimitingReason = "the desired replica count is above the maximum replica count"
+		}
+
+		// make sure the desiredReplicas is between the allowed boundaries.
+		if desiredReplicas > maximumAllowedReplicas {
+			logger.Info("Returning replicas, condition and reason", "replicas", maximumAllowedReplicas, "condition", possibleLimitingCondition, reasonPromLabel, possibleLimitingReason)
+			normalizedReplicas = maximumAllowedReplicas
+		} else {
+			possibleLimitingCondition = "DesiredWithinRange"
+			possibleLimitingReason = desiredCountAcceptable
+			normalizedReplicas = desiredReplicas
+		}
 	}
 
-	// make sure the desiredReplicas is between the allowed boundaries.
-	if desiredReplicas > maximumAllowedReplicas {
-		logger.Info("Returning replicas, condition and reason", "replicas", maximumAllowedReplicas, "condition", possibleLimitingCondition, reasonPromLabel, possibleLimitingReason)
-		return maximumAllowedReplicas, possibleLimitingCondition, possibleLimitingReason
-	}
+	// Refresh both restricted_scaling gauges before returning so a stale value
+	// cannot remain "stuck" across reconciles (see CASCL-1709).
+	downscaleLabels := getPrometheusLabels(wpa)
+	downscaleLabels[reasonPromLabel] = downscaleCappingPromLabelVal
+	restrictedScaling.With(downscaleLabels).Set(boolToFloat64(downscaleCapping))
 
-	possibleLimitingCondition = "DesiredWithinRange"
-	possibleLimitingReason = desiredCountAcceptable
+	upscaleLabels := getPrometheusLabels(wpa)
+	upscaleLabels[reasonPromLabel] = upscaleCappingPromLabelVal
+	restrictedScaling.With(upscaleLabels).Set(boolToFloat64(upscaleCapping))
 
-	return desiredReplicas, possibleLimitingCondition, possibleLimitingReason
+	return normalizedReplicas, possibleLimitingCondition, possibleLimitingReason
 }
 
 // Scaleup limit is used to maximize the upscaling rate.

--- a/controllers/datadoghq/watermarkpodautoscaler_controller.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller.go
@@ -952,9 +952,25 @@ func convertDesiredReplicasWithRules(logger logr.Logger, wpa *datadoghqv1alpha1.
 	var possibleLimitingCondition string
 	var possibleLimitingReason string
 
+	// Track the capping decisions so that both the downscale_capping and
+	// upscale_capping restricted_scaling gauges are refreshed on every return
+	// path. Previously these gauges were only updated on the specific branch
+	// that computed them, so a gauge set to 1 during one reconcile could stay
+	// "stuck" at 1 on subsequent reconciles that no longer capped in that
+	// direction (see CASCL-1709).
+	downscaleCapping := false
+	upscaleCapping := false
+	defer func() {
+		downscaleLabels := getPrometheusLabels(wpa)
+		downscaleLabels[reasonPromLabel] = downscaleCappingPromLabelVal
+		restrictedScaling.With(downscaleLabels).Set(boolToFloat64(downscaleCapping))
+
+		upscaleLabels := getPrometheusLabels(wpa)
+		upscaleLabels[reasonPromLabel] = upscaleCappingPromLabelVal
+		restrictedScaling.With(upscaleLabels).Set(boolToFloat64(upscaleCapping))
+	}()
+
 	scaleDownLimit := calculateScaleDownLimit(wpa, currentReplicas)
-	wpaLabels := getPrometheusLabels(wpa)
-	wpaLabels[reasonPromLabel] = "downscale_capping"
 
 	// Compute the maximum and minimum number of replicas we can have
 	switch {
@@ -962,7 +978,7 @@ func convertDesiredReplicasWithRules(logger logr.Logger, wpa *datadoghqv1alpha1.
 		minimumAllowedReplicas = 1
 	case desiredReplicas < scaleDownLimit:
 		minimumAllowedReplicas = int32(math.Max(float64(scaleDownLimit), float64(wpaMinReplicas)))
-		restrictedScaling.With(wpaLabels).Set(1)
+		downscaleCapping = true
 		possibleLimitingCondition = "ScaleDownLimit"
 		possibleLimitingReason = "the desired replica count is decreasing faster than the maximum scale rate"
 		logger.Info("Downscaling rate higher than limit set by `scaleDownLimitFactor`, capping the maximum downscale to 'minimumAllowedReplicas'", "scaleDownLimitFactor", fmt.Sprintf("%.1f", float64(wpa.Spec.ScaleDownLimitFactor.MilliValue()/1000)), "wpaMinReplicas", wpaMinReplicas, "minimumAllowedReplicas", minimumAllowedReplicas)
@@ -972,7 +988,6 @@ func convertDesiredReplicasWithRules(logger logr.Logger, wpa *datadoghqv1alpha1.
 		}
 	case desiredReplicas >= scaleDownLimit:
 		minimumAllowedReplicas = wpaMinReplicas
-		restrictedScaling.With(wpaLabels).Set(0)
 		possibleLimitingCondition = "TooFewReplicas"
 		possibleLimitingReason = "the desired replica count is below the minimum replica count"
 	}
@@ -985,14 +1000,12 @@ func convertDesiredReplicasWithRules(logger logr.Logger, wpa *datadoghqv1alpha1.
 
 	if desiredReplicas > scaleUpLimit {
 		maximumAllowedReplicas = int32(math.Min(float64(scaleUpLimit), float64(wpaMaxReplicas)))
-		wpaLabels[reasonPromLabel] = upscaleCappingPromLabelVal
-		restrictedScaling.With(wpaLabels).Set(1)
+		upscaleCapping = true
 		logger.Info("Upscaling rate higher than limit set by 'ScaleUpLimitFactor', capping the maximum upscale to 'maximumAllowedReplicas'", "scaleUpLimitFactor", fmt.Sprintf("%.1f", float64(wpa.Spec.ScaleUpLimitFactor.MilliValue()/1000)), "wpaMaxReplicas", wpaMaxReplicas, "maximumAllowedReplicas", maximumAllowedReplicas)
 		possibleLimitingCondition = "ScaleUpLimit"
 		possibleLimitingReason = "the desired replica count is increasing faster than the maximum scale rate"
 	} else {
 		maximumAllowedReplicas = wpaMaxReplicas
-		restrictedScaling.With(wpaLabels).Set(0)
 		possibleLimitingCondition = "TooManyReplicas"
 		possibleLimitingReason = "the desired replica count is above the maximum replica count"
 	}

--- a/controllers/datadoghq/watermarkpodautoscaler_controller_test.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller_test.go
@@ -2435,8 +2435,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			require.Equal(t, tt.possibleLimitingCondition, cond)
 			require.Equal(t, tt.possibleLimitingReason, rea)
 
-			require.Equal(t, tt.expectedUpscaleCapping, getGaugeVal(t, restrictedScaling.With(getRestrictedScalingLabels(tt.wpa, upscaleCappingPromLabelVal))), "upscale_capping gauge")
-			require.Equal(t, tt.expectedDownscaleCapping, getGaugeVal(t, restrictedScaling.With(getRestrictedScalingLabels(tt.wpa, downscaleCappingPromLabelVal))), "downscale_capping gauge")
+			require.InDelta(t, tt.expectedUpscaleCapping, getGaugeVal(t, restrictedScaling.With(getRestrictedScalingLabels(tt.wpa, upscaleCappingPromLabelVal))), 0.00001, "upscale_capping gauge")
+			require.InDelta(t, tt.expectedDownscaleCapping, getGaugeVal(t, restrictedScaling.With(getRestrictedScalingLabels(tt.wpa, downscaleCappingPromLabelVal))), 0.00001, "downscale_capping gauge")
 		})
 	}
 }
@@ -2462,28 +2462,28 @@ func TestConvertDesiredReplicasWithRulesResetsRestrictedScaling(t *testing.T) {
 	// 1. A large desired replica count triggers upscale capping -> gauge = 1.
 	_, cond, _ := convertDesiredReplicasWithRules(logger, wpa, 50, 90, *wpa.Spec.MinReplicas, wpa.Spec.MaxReplicas, 50)
 	require.Equal(t, "ScaleUpLimit", cond)
-	require.Equal(t, float64(1), getGaugeVal(t, restrictedScaling.With(upscaleLabels)), "upscale_capping should be set when scaling is capped")
-	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)))
+	require.InDelta(t, float64(1), getGaugeVal(t, restrictedScaling.With(upscaleLabels)), 0.00001, "upscale_capping should be set when scaling is capped")
+	require.InDelta(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)), 0.00001)
 
 	// 2. A within-range desired replica count no longer caps upscaling. The
 	// gauge must be reset back to 0 instead of remaining stuck at 1.
 	_, cond, _ = convertDesiredReplicasWithRules(logger, wpa, 50, 55, *wpa.Spec.MinReplicas, wpa.Spec.MaxReplicas, 50)
 	require.Equal(t, "DesiredWithinRange", cond)
-	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)), "upscale_capping should reset to 0 once scaling is no longer capped")
-	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)))
+	require.InDelta(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)), 0.00001, "upscale_capping should reset to 0 once scaling is no longer capped")
+	require.InDelta(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)), 0.00001)
 
 	// 3. A small desired replica count triggers downscale capping -> gauge = 1,
 	// and the upscale gauge remains 0.
 	_, cond, _ = convertDesiredReplicasWithRules(logger, wpa, 50, 10, *wpa.Spec.MinReplicas, wpa.Spec.MaxReplicas, 50)
 	require.Equal(t, "ScaleDownLimit", cond)
-	require.Equal(t, float64(1), getGaugeVal(t, restrictedScaling.With(downscaleLabels)), "downscale_capping should be set when scaling is capped")
-	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)))
+	require.InDelta(t, float64(1), getGaugeVal(t, restrictedScaling.With(downscaleLabels)), 0.00001, "downscale_capping should be set when scaling is capped")
+	require.InDelta(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)), 0.00001)
 
 	// 4. Back within range: the downscale gauge must reset to 0 as well.
 	_, cond, _ = convertDesiredReplicasWithRules(logger, wpa, 50, 55, *wpa.Spec.MinReplicas, wpa.Spec.MaxReplicas, 50)
 	require.Equal(t, "DesiredWithinRange", cond)
-	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)), "downscale_capping should reset to 0 once scaling is no longer capped")
-	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)))
+	require.InDelta(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)), 0.00001, "downscale_capping should reset to 0 once scaling is no longer capped")
+	require.InDelta(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)), 0.00001)
 }
 
 func TestSetCondition(t *testing.T) {

--- a/controllers/datadoghq/watermarkpodautoscaler_controller_test.go
+++ b/controllers/datadoghq/watermarkpodautoscaler_controller_test.go
@@ -2322,6 +2322,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 		normalizedReplicas        int32
 		currentReplicas           int32
 		readyReplicas             int32
+		expectedUpscaleCapping    float64
+		expectedDownscaleCapping  float64
 	}{
 		{
 			name:                      "desiredReplicas < wpaMinReplicas < scaleDownLimit",
@@ -2332,6 +2334,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			normalizedReplicas:        45,
 			readyReplicas:             50,
 			wpa:                       makeWPASpec(15, 80, 30, 10),
+			expectedUpscaleCapping:    0,
+			expectedDownscaleCapping:  1,
 		},
 		{
 			name:                      "desiredReplicas < scaleDownLimit < wpaMinReplicas ",
@@ -2342,6 +2346,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			normalizedReplicas:        30,
 			readyReplicas:             50,
 			wpa:                       makeWPASpec(30, 80, 30, 70),
+			expectedUpscaleCapping:    0,
+			expectedDownscaleCapping:  1,
 		},
 		{
 			name:                      "wpaMinReplicas < desiredReplicas < scaleDownLimit",
@@ -2352,6 +2358,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			normalizedReplicas:        35,
 			readyReplicas:             50,
 			wpa:                       makeWPASpec(10, 6, 30, 30),
+			expectedUpscaleCapping:    0,
+			expectedDownscaleCapping:  1,
 		},
 		{
 			name:                      "wpaMinReplicas < scaleDownLimit < desiredReplicas",
@@ -2362,6 +2370,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			normalizedReplicas:        40,
 			readyReplicas:             50,
 			wpa:                       makeWPASpec(10, 80, 30, 30),
+			expectedUpscaleCapping:    0,
+			expectedDownscaleCapping:  0,
 		},
 		{
 			name:                      "wpaMaxReplicas < scaleUpLimit < desiredReplicas",
@@ -2372,6 +2382,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			normalizedReplicas:        60,
 			readyReplicas:             50,
 			wpa:                       makeWPASpec(3, 60, 20, 0),
+			expectedUpscaleCapping:    1,
+			expectedDownscaleCapping:  0,
 		},
 		{
 			name:                      "wpaMaxReplicas < desiredReplicas < scaleUpLimit",
@@ -2382,6 +2394,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			normalizedReplicas:        60,
 			readyReplicas:             50,
 			wpa:                       makeWPASpec(3, 60, 40, 0),
+			expectedUpscaleCapping:    0,
+			expectedDownscaleCapping:  0,
 		},
 		{
 			name:                      "desiredReplicas < wpaMaxReplicas < scaleUpLimit",
@@ -2392,6 +2406,8 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			normalizedReplicas:        55,
 			readyReplicas:             50,
 			wpa:                       makeWPASpec(3, 60, 40, 0),
+			expectedUpscaleCapping:    0,
+			expectedDownscaleCapping:  0,
 		},
 		{
 			name:                      "desiredReplicas < readyReplicas < minimumAllowedReplicas", // minimumAllowdReplicas = 43
@@ -2402,16 +2418,72 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 			normalizedReplicas:        50,
 			readyReplicas:             40,
 			wpa:                       makeWPASpec(3, 60, 15, 15),
+			expectedUpscaleCapping:    0,
+			expectedDownscaleCapping:  1,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Seed both restricted_scaling gauges to 1 to emulate a previous
+			// reconcile that capped scaling. convertDesiredReplicasWithRules must
+			// refresh both gauges so a stale value cannot remain "stuck" (CASCL-1709).
+			restrictedScaling.With(getRestrictedScalingLabels(tt.wpa, upscaleCappingPromLabelVal)).Set(1)
+			restrictedScaling.With(getRestrictedScalingLabels(tt.wpa, downscaleCappingPromLabelVal)).Set(1)
+
 			des, cond, rea := convertDesiredReplicasWithRules(logf.Log.WithName(tt.name), tt.wpa, tt.currentReplicas, tt.desiredReplicas, *tt.wpa.Spec.MinReplicas, tt.wpa.Spec.MaxReplicas, tt.readyReplicas)
 			require.Equal(t, tt.normalizedReplicas, des)
 			require.Equal(t, tt.possibleLimitingCondition, cond)
 			require.Equal(t, tt.possibleLimitingReason, rea)
+
+			require.Equal(t, tt.expectedUpscaleCapping, getGaugeVal(t, restrictedScaling.With(getRestrictedScalingLabels(tt.wpa, upscaleCappingPromLabelVal))), "upscale_capping gauge")
+			require.Equal(t, tt.expectedDownscaleCapping, getGaugeVal(t, restrictedScaling.With(getRestrictedScalingLabels(tt.wpa, downscaleCappingPromLabelVal))), "downscale_capping gauge")
 		})
 	}
+}
+
+// TestConvertDesiredReplicasWithRulesResetsRestrictedScaling reproduces the
+// scenario described in CASCL-1709: once the upscale (or downscale) capping
+// gauge is set to 1, a subsequent reconcile that no longer caps scaling in that
+// direction must reset the gauge back to 0. Before the fix the gauge stayed
+// "stuck" at 1 until a metric-fetch error or a controller restart cleared it.
+func TestConvertDesiredReplicasWithRulesResetsRestrictedScaling(t *testing.T) {
+	logf.SetLogger(zap.New())
+
+	wpa := makeWPASpec(3, 60, 20, 20)
+	logger := logf.Log.WithName(t.Name())
+
+	upscaleLabels := getRestrictedScalingLabels(wpa, upscaleCappingPromLabelVal)
+	downscaleLabels := getRestrictedScalingLabels(wpa, downscaleCappingPromLabelVal)
+
+	// Start from a clean state.
+	restrictedScaling.With(upscaleLabels).Set(0)
+	restrictedScaling.With(downscaleLabels).Set(0)
+
+	// 1. A large desired replica count triggers upscale capping -> gauge = 1.
+	_, cond, _ := convertDesiredReplicasWithRules(logger, wpa, 50, 90, *wpa.Spec.MinReplicas, wpa.Spec.MaxReplicas, 50)
+	require.Equal(t, "ScaleUpLimit", cond)
+	require.Equal(t, float64(1), getGaugeVal(t, restrictedScaling.With(upscaleLabels)), "upscale_capping should be set when scaling is capped")
+	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)))
+
+	// 2. A within-range desired replica count no longer caps upscaling. The
+	// gauge must be reset back to 0 instead of remaining stuck at 1.
+	_, cond, _ = convertDesiredReplicasWithRules(logger, wpa, 50, 55, *wpa.Spec.MinReplicas, wpa.Spec.MaxReplicas, 50)
+	require.Equal(t, "DesiredWithinRange", cond)
+	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)), "upscale_capping should reset to 0 once scaling is no longer capped")
+	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)))
+
+	// 3. A small desired replica count triggers downscale capping -> gauge = 1,
+	// and the upscale gauge remains 0.
+	_, cond, _ = convertDesiredReplicasWithRules(logger, wpa, 50, 10, *wpa.Spec.MinReplicas, wpa.Spec.MaxReplicas, 50)
+	require.Equal(t, "ScaleDownLimit", cond)
+	require.Equal(t, float64(1), getGaugeVal(t, restrictedScaling.With(downscaleLabels)), "downscale_capping should be set when scaling is capped")
+	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)))
+
+	// 4. Back within range: the downscale gauge must reset to 0 as well.
+	_, cond, _ = convertDesiredReplicasWithRules(logger, wpa, 50, 55, *wpa.Spec.MinReplicas, wpa.Spec.MaxReplicas, 50)
+	require.Equal(t, "DesiredWithinRange", cond)
+	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(downscaleLabels)), "downscale_capping should reset to 0 once scaling is no longer capped")
+	require.Equal(t, float64(0), getGaugeVal(t, restrictedScaling.With(upscaleLabels)))
 }
 
 func TestSetCondition(t *testing.T) {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"a1524404-5a8a-45de-90f2-6a39ab236136","workflowId":"b9e0cc59-9b36-4a65-ba54-1566f2f1e5da","codeChangeId":"b9e0cc59-9b36-4a65-ba54-1566f2f1e5da","sourceType":"chat"} -->
### What does this PR do?

Fixes the `watermarkpodautoscaler.wpa_controller_restricted_scaling{reason:upscale_capping}` (and `downscale_capping`) gauge staying "stuck" at `1` after scaling was capped once. `convertDesiredReplicasWithRules` now deterministically refreshes both the `upscale_capping` and `downscale_capping` gauges on every return path, so a gauge set to `1` during one reconcile is reset to `0` on subsequent reconciles that no longer cap in that direction.

### Motivation

Addresses Jira CASCL-1709. During an incident, a user observed that `upscale_capping` kept reporting `1` long after the proposed replica count dropped below the effective replica count — it only reset on a metric-fetch error or controller restart. Root cause is in `convertDesiredReplicasWithRules`:

- The shared label map was initialized to `downscale_capping` and only switched to `upscale_capping` inside the "capped" branch. On the non-capping path the code called `Set(0)` while the label was still `downscale_capping`, so `upscale_capping` was never reset.
- The early `return` on the downscale-capping / below-minimum path skipped the upscale block entirely, leaving `upscale_capping` untouched.
- The `wpaMinReplicas == 0` switch case never touched `downscale_capping`.

`normalizeDesiredReplicas` → `convertDesiredReplicasWithRules` runs on every successful reconcile, so correcting this function is sufficient to keep the gauges accurate.

### Changes

- `controllers/datadoghq/watermarkpodautoscaler_controller.go`: track capping decisions with local `downscaleCapping` / `upscaleCapping` booleans and set both gauges from a single `defer`, each with its own freshly-built label map. Replaced the branch-local `restrictedScaling.With(...).Set(...)` calls with flag assignments. Scaling behavior (returned replicas, conditions, reasons) is unchanged; only metric bookkeeping is corrected.
- `controllers/datadoghq/metrics.go`: add a small `boolToFloat64` helper for the 1/0 gauge representation.
- `controllers/datadoghq/watermarkpodautoscaler_controller_test.go`: assert the `upscale_capping` / `downscale_capping` gauge values in `TestConvertDesiredReplicasWithRules` (seeding both to `1` beforehand to prove they are refreshed), and add `TestConvertDesiredReplicasWithRulesResetsRestrictedScaling`, a regression test that reproduces the CASCL-1709 sequence (cap → within-range reset) for both directions. Float gauge assertions use `require.InDelta` (matching the existing convention in this file) to satisfy the `testifylint` `float-compare` linter.

### Additional Notes

No API/CRD changes, so no `make generate`/`manifests` needed. On metric-fetch errors the replica calculator already deletes these gauges, which is consistent with the previously reported "resets on error" behavior.

### Describe your test plan

- `go test ./controllers/datadoghq/` — full package suite passes.
- `go test ./controllers/datadoghq/ -run 'TestConvertDesiredReplicasWithRules' -v` — new and updated assertions pass; the regression test fails against the old code and passes with the fix.
- `testifylint ./controllers/datadoghq/` — clean (the float gauge assertions now use `require.InDelta`, resolving the CI lint failures).
- `go vet ./controllers/datadoghq/` and `gofmt -l` are clean.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/a1524404-5a8a-45de-90f2-6a39ab236136)

Comment @datadog to request changes